### PR TITLE
Adding CMakeLists to allow building with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,18 @@
 /.project
 /.settings/
 /.vscode/
+
+#
+# Cmake
+#
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+project( libonnx )
+cmake_minimum_required( VERSION 3.19 )
+
+option(BUILD_EXAMPLES "Build the examples" OFF)
+
+add_subdirectory(src)
+add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project( libonnx )
 cmake_minimum_required( VERSION 3.19 )
 
 option(BUILD_EXAMPLES "Build the examples" OFF)
+option(BUILD_TESTS    "Build the tests" OFF)
 
 add_subdirectory(src)
 add_subdirectory(examples)
+add_subdirectory(tests)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+if (BUILD_EXAMPLES)
+    find_package(PkgConfig REQUIRED)
+    find_package(SDL2 REQUIRED)
+    pkg_check_modules(sdl2_gfx REQUIRED sdl2_gfx)
+
+    add_executable(benchmark benchmark/main.c)
+    target_link_libraries(benchmark libonnx_lib)
+
+    add_executable(hello hello/main.c)
+    target_link_libraries(hello libonnx_lib)
+
+    add_executable(mnist mnist/main.c)
+    target_include_directories(mnist PRIVATE ${SDL2_INCLUDE_DIRS}/.. ${sdl2_gfx_INCLUDE_DIRS}/..)
+    target_link_directories(mnist PRIVATE ${sdl2_gfx_LIBRARY_DIRS})
+    target_link_libraries(mnist libonnx_lib ${SDL2_LIBRARIES} ${sdl2_gfx_LIBRARIES})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB_RECURSE LIBONNX_LIB_SOURCES ./**.c)
+file(GLOB_RECURSE LIBONNX_LIB_HEADERS ./**.h)
+
+add_library(libonnx_lib ${LIBONNX_LIB_SOURCES})
+target_include_directories(libonnx_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+if (APPLE)
+    target_compile_options(libonnx_lib PUBLIC -I${CMAKE_OSX_SYSROOT}/usr/include/malloc/)
+endif(APPLE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+if (BUILD_TESTS)
+    enable_testing()
+
+    add_executable(libonnx_test main.c)
+    target_link_libraries(libonnx_test libonnx_lib)
+
+    add_test(libonnx_test_model libonnx_test "${CMAKE_SOURCE_DIR}/tests/model")
+    add_test(libonnx_test_node libonnx_test "${CMAKE_SOURCE_DIR}/tests/node")
+    add_test(libonnx_test_pytorch-converted libonnx_test "${CMAKE_SOURCE_DIR}/tests/pytorch-converted")
+    add_test(libonnx_test_pytorch-operator libonnx_test "${CMAKE_SOURCE_DIR}/tests/pytorch-operator")
+    add_test(libonnx_test_simple libonnx_test "${CMAKE_SOURCE_DIR}/tests/simple")
+
+endif(BUILD_TESTS)


### PR DESCRIPTION
Adding simple, initial CMake build scripts.

To build:
```
$ mkdir build && cd build
$ cmake ..
$ cmake --build . --target all
```

There's an option `BUILD_EXAMPLES` that can enable/disable building the samples, e.g.
```
$ cmake -DBUILD_EXAMPLES=ON ..
```