### PR TITLE
[Constant] use correct argument for onnx_tensor_reinit function

### DIFF
--- a/src/default/Constant.c
+++ b/src/default/Constant.c
@@ -55,7 +55,7 @@ static int Constant_init(struct onnx_node_t * n)
 				if((strcmp(attr->name, "value_strings") == 0) && (attr->n_strings > 0))
 				{
 					if((y->ndim != 1) || (y->dims[0] != attr->n_strings) || (y->type != ONNX_TENSOR_TYPE_STRING))
-						onnx_tensor_reinit(y, ONNX_TENSOR_TYPE_STRING, (int[]){ attr->n_ints }, 1);
+						onnx_tensor_reinit(y, ONNX_TENSOR_TYPE_STRING, (int[]){ attr->n_strings }, 1);
 					if(y->datas && attr->strings)
 					{
 						char ** str = (char **)y->datas;

--- a/tests/node/test_constant_value_strings/model.onnx
+++ b/tests/node/test_constant_value_strings/model.onnx
@@ -1,0 +1,7 @@
+onnx-example:e
+>values"Constant**
+value_stringsJaJbJcJdJcatJtiger test-constantb
+values
+
+
+B

--- a/tests/node/test_constant_value_strings/test.py
+++ b/tests/node/test_constant_value_strings/test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import onnx
+import onnx.helper
+import numpy as np
+
+values = ['a','b','c','d','cat','tiger',]
+
+output_tensor = onnx.helper.make_tensor("values", onnx.TensorProto.STRING, [len(values)], [bytes(i, 'utf-8') for i in values])
+
+outputs = [onnx.helper.make_tensor_value_info("values", onnx.TensorProto.STRING, [len(values)])]
+node = onnx.helper.make_node(
+    'Constant',
+    inputs=[],
+    outputs=['values'],
+    value_strings=values
+)
+
+graph = onnx.helper.make_graph(
+    [node],
+    'test-constant',
+    [],
+    outputs)
+model = onnx.helper.make_model(graph, producer_name='onnx-example')
+onnx.save_model(model, 'model.onnx')
+onnx.save_tensor(output_tensor, 'test_data_set_0/output_0.pb')

--- a/tests/node/test_constant_value_strings/test_data_set_0/output_0.pb
+++ b/tests/node/test_constant_value_strings/test_data_set_0/output_0.pb
@@ -1,0 +1,1 @@
+2a2b2c2d2cat2tigerBvalues


### PR DESCRIPTION
When `value_strings` attribute is specified in `Constant_init` function, 3rd argument (`dims`) of `onnx_tensor_reinit` is set by the following code.

```c
(int[]){ attr->n_ints }
```

But I guess `attr->n_strings` should be used instead of `attr->n_ints`.

----

I added the test case `node/test_constant_value_strings` to make sure `value_strings` attribute is handled properly.
However, the test case passes even with original code because `onnx_tensor_reinit` function won't be called when output tensor is compatible with specified attribute.