### PR TITLE
[Round] check and set the floating-point rounding mode to FE_TONEAREST

### DIFF
--- a/src/default/Round.c
+++ b/src/default/Round.c
@@ -1,3 +1,4 @@
+#include <fenv.h>
 #include <onnx.h>
 
 static int Round_init(struct onnx_node_t * n)
@@ -26,12 +27,20 @@ static void Round_float16(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
+	int r = fegetround();
+	if (r != FE_TONEAREST) {
+		fesetround(FE_TONEAREST);
+	}
 	float v;
 
 	for(size_t i = 0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(rintf(v));
+		py[i] = float32_to_float16(nearbyintf(v));
+	}
+
+	if (r != FE_TONEAREST) {
+		fesetround(r);
 	}
 }
 
@@ -41,9 +50,17 @@ static void Round_float32(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
+	int r = fegetround();
+	if (r != FE_TONEAREST) {
+		fesetround(FE_TONEAREST);
+	}
 
 	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = rintf(px[i]);
+		py[i] = nearbyintf(px[i]);
+
+	if (r != FE_TONEAREST) {
+		fesetround(r);
+	}
 }
 
 static void Round_float64(struct onnx_node_t * n)
@@ -52,9 +69,17 @@ static void Round_float64(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
+	int r = fegetround();
+	if (r != FE_TONEAREST) {
+		fesetround(FE_TONEAREST);
+	}
 
 	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = rint(px[i]);
+		py[i] = nearbyint(px[i]);
+
+	if (r != FE_TONEAREST) {
+		fesetround(r);
+	}
 }
 
 void resolver_default_op_Round(struct onnx_node_t * n)


### PR DESCRIPTION
This PR explicitly sets the floating-point rounding mode to `FE_TONEAREST`.

In original implementation, if the rounding mode other than `FE_TONEAREST` is set prior to calling `onnx_run` function, the test case `[test_round]` fails.

Here's the code to set the rounding mode.
```c
#include <fenv.h>

	// fesetround(FE_TONEAREST);
	// fesetround(FE_DOWNWARD);
	// fesetround(FE_UPWARD);
	// fesetround(FE_TOWARDZERO);
```

It also uses `nearbyintf` / `nearbyint` function instead of `rintf` / `rint` function. The difference between the functions is `nearbyintf` / `nearbyint` does not report the inexact floating point exception `FE_INEXACT`.
