### PR TITLE
Critical fixes for memory leakage and compatibility

### DIFF
--- a/src/default/Abs.c
+++ b/src/default/Abs.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Abs_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,9 @@ static void Abs_int8(struct onnx_node_t * n)
 	int8_t * px = (int8_t *)x->datas;
 	int8_t * py = (int8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -38,7 +40,9 @@ static void Abs_int16(struct onnx_node_t * n)
 	int16_t * px = (int16_t *)x->datas;
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -49,7 +53,9 @@ static void Abs_int32(struct onnx_node_t * n)
 	int32_t * px = (int32_t *)x->datas;
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -60,7 +66,9 @@ static void Abs_int64(struct onnx_node_t * n)
 	int64_t * px = (int64_t *)x->datas;
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -71,7 +79,9 @@ static void Abs_uint8(struct onnx_node_t * n)
 	uint8_t * px = (uint8_t *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -82,7 +92,9 @@ static void Abs_uint16(struct onnx_node_t * n)
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -93,7 +105,9 @@ static void Abs_uint32(struct onnx_node_t * n)
 	uint32_t * px = (uint32_t *)x->datas;
 	uint32_t * py = (uint32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -104,7 +118,9 @@ static void Abs_uint64(struct onnx_node_t * n)
 	uint64_t * px = (uint64_t *)x->datas;
 	uint64_t * py = (uint64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? -px[i] : px[i];
 }
 
@@ -116,7 +132,9 @@ static void Abs_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(fabsf(v));
@@ -131,7 +149,9 @@ static void Abs_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(fabsf(v));
@@ -145,7 +165,9 @@ static void Abs_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = fabsf(px[i]);
 }
 
@@ -156,7 +178,9 @@ static void Abs_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = fabs(px[i]);
 }
 

--- a/src/default/Acos.c
+++ b/src/default/Acos.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Acos_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,12 @@ static void Acos_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(acosf(v));
+		py[i] = float32_to_float16(acos(v));
 	}
 }
 
@@ -42,8 +44,10 @@ static void Acos_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = acosf(px[i]);
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
+		py[i] = acos(px[i]);
 }
 
 static void Acos_float64(struct onnx_node_t * n)
@@ -53,7 +57,9 @@ static void Acos_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+
+	for(i = 0, l = y->ndata; i < l; i++)
 		py[i] = acos(px[i]);
 }
 

--- a/src/default/Acosh.c
+++ b/src/default/Acosh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Acosh_init(struct onnx_node_t * n)
 {
@@ -32,7 +32,7 @@ static void Acosh_float16(struct onnx_node_t * n)
 	for(i = 0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(acoshf(v));
+		py[i] = float32_to_float16(acosh(v));
 	}
 }
 
@@ -45,7 +45,7 @@ static void Acosh_float32(struct onnx_node_t * n)
 	size_t i, l;
 
 	for(i = 0, l = y->ndata; i < l; i++)
-		py[i] = acoshf(px[i]);
+		py[i] = acosh(px[i]);
 }
 
 static void Acosh_float64(struct onnx_node_t * n)

--- a/src/default/Add.c
+++ b/src/default/Add.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Add_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Add_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Add_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Add_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Add_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Add_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Add_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Add_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Add_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Add_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Add_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Add_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Add_13_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i, l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/And.c
+++ b/src/default/And.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int And_7_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void And_7_bool(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/ArgMax.c
+++ b/src/default/ArgMax.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int axis;

--- a/src/default/ArgMin.c
+++ b/src/default/ArgMin.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int axis;

--- a/src/default/Asin.c
+++ b/src/default/Asin.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Asin_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Asin_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(asinf(v));
+		py[i] = float32_to_float16(asin(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Asin_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = asinf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = asin(px[i]);
 }
 
 static void Asin_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Asin_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = asin(px[i]);
 }
 

--- a/src/default/Asinh.c
+++ b/src/default/Asinh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Asinh_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Asinh_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(asinhf(v));
+		py[i] = float32_to_float16(asinh(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Asinh_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = asinhf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = asinh(px[i]);
 }
 
 static void Asinh_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Asinh_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = asinh(px[i]);
 }
 

--- a/src/default/Atan.c
+++ b/src/default/Atan.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Atan_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Atan_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(atanf(v));
@@ -42,7 +43,8 @@ static void Atan_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = atanf(px[i]);
 }
 
@@ -53,7 +55,8 @@ static void Atan_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = atan(px[i]);
 }
 

--- a/src/default/Atanh.c
+++ b/src/default/Atanh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Atanh_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Atanh_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(atanhf(v));
+		py[i] = float32_to_float16(atanh(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Atanh_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = atanhf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = atanh(px[i]);
 }
 
 static void Atanh_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Atanh_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = atanh(px[i]);
 }
 

--- a/src/default/AveragePool.c
+++ b/src/default/AveragePool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 enum auto_pad_t {
 	AUTO_PAD_NOTSET		= 0,

--- a/src/default/BatchNormalization.c
+++ b/src/default/BatchNormalization.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float epsilon;

--- a/src/default/BitShift.c
+++ b/src/default/BitShift.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int isleft;
@@ -51,7 +51,8 @@ static void BitShift_uint8(struct onnx_node_t * n)
 
 	if(pdat->isleft)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -60,7 +61,8 @@ static void BitShift_uint8(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +83,8 @@ static void BitShift_uint16(struct onnx_node_t * n)
 
 	if(pdat->isleft)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -90,7 +93,8 @@ static void BitShift_uint16(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -111,7 +115,8 @@ static void BitShift_uint32(struct onnx_node_t * n)
 
 	if(pdat->isleft)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -120,7 +125,8 @@ static void BitShift_uint32(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -141,7 +147,8 @@ static void BitShift_uint64(struct onnx_node_t * n)
 
 	if(pdat->isleft)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -150,7 +157,8 @@ static void BitShift_uint64(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Cast.c
+++ b/src/default/Cast.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t to;

--- a/src/default/Ceil.c
+++ b/src/default/Ceil.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Ceil_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Ceil_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_float16(ceilf(v));
@@ -43,7 +44,8 @@ static void Ceil_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(ceilf(v));
@@ -57,7 +59,8 @@ static void Ceil_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = ceilf(px[i]);
 }
 
@@ -68,7 +71,8 @@ static void Ceil_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = ceil(px[i]);
 }
 

--- a/src/default/Celu.c
+++ b/src/default/Celu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -46,8 +46,9 @@ static void Celu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = max((float)0.0, (float)px[i]) + min((float)0.0, (float)pdat->alpha * (expf(px[i] / pdat->alpha) - 1));
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = max((float)0.0, (float)px[i]) + min((float)0.0, (float)pdat->alpha * (exp(px[i] / pdat->alpha) - 1));
 }
 
 void resolver_default_op_Celu(struct onnx_node_t * n)

--- a/src/default/Clip.c
+++ b/src/default/Clip.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 union onnx_scalar_t {
 	uint8_t v_bool;
@@ -88,7 +88,8 @@ static void Clip_int8(struct onnx_node_t * n)
 	int8_t minv = pdat->pmin ? pdat->pmin->v_int8 : INT8_MIN;
 	int8_t maxv = pdat->pmax ? pdat->pmax->v_int8 : INT8_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -109,7 +110,8 @@ static void Clip_int16(struct onnx_node_t * n)
 	int16_t minv = pdat->pmin ? pdat->pmin->v_int16 : INT16_MIN;
 	int16_t maxv = pdat->pmax ? pdat->pmax->v_int16 : INT16_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -130,7 +132,8 @@ static void Clip_int32(struct onnx_node_t * n)
 	int32_t minv = pdat->pmin ? pdat->pmin->v_int32 : INT32_MIN;
 	int32_t maxv = pdat->pmax ? pdat->pmax->v_int32 : INT32_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -151,7 +154,8 @@ static void Clip_int64(struct onnx_node_t * n)
 	int64_t minv = pdat->pmin ? pdat->pmin->v_int64 : INT64_MIN;
 	int64_t maxv = pdat->pmax ? pdat->pmax->v_int64 : INT64_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -172,7 +176,8 @@ static void Clip_uint8(struct onnx_node_t * n)
 	uint8_t minv = pdat->pmin ? pdat->pmin->v_uint8 : 0;
 	uint8_t maxv = pdat->pmax ? pdat->pmax->v_uint8 : UINT8_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -193,7 +198,8 @@ static void Clip_uint16(struct onnx_node_t * n)
 	uint16_t minv = pdat->pmin ? pdat->pmin->v_uint16 : 0;
 	uint16_t maxv = pdat->pmax ? pdat->pmax->v_uint16 : UINT16_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -214,7 +220,8 @@ static void Clip_uint32(struct onnx_node_t * n)
 	uint32_t minv = pdat->pmin ? pdat->pmin->v_uint32 : 0;
 	uint32_t maxv = pdat->pmax ? pdat->pmax->v_uint32 : UINT32_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -235,7 +242,8 @@ static void Clip_uint64(struct onnx_node_t * n)
 	uint64_t minv = pdat->pmin ? pdat->pmin->v_uint64 : 0;
 	uint64_t maxv = pdat->pmax ? pdat->pmax->v_uint64 : UINT64_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -257,7 +265,8 @@ static void Clip_bfloat16(struct onnx_node_t * n)
 	float maxv = bfloat16_to_float32(pdat->pmax ? pdat->pmax->v_bfloat16 : float32_to_bfloat16(+FLT_MAX));
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		if(v < minv)
@@ -281,7 +290,8 @@ static void Clip_float16(struct onnx_node_t * n)
 	float maxv = float16_to_float32(pdat->pmax ? pdat->pmax->v_float16 : float32_to_float16(+FLT_MAX));
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v < minv)
@@ -304,7 +314,8 @@ static void Clip_float32(struct onnx_node_t * n)
 	float minv = pdat->pmin ? pdat->pmin->v_float32 : -FLT_MAX;
 	float maxv = pdat->pmax ? pdat->pmax->v_float32 : +FLT_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;
@@ -325,7 +336,8 @@ static void Clip_float64(struct onnx_node_t * n)
 	double minv = pdat->pmin ? pdat->pmin->v_float64 : -DBL_MAX;
 	double maxv = pdat->pmax ? pdat->pmax->v_float64 : +DBL_MAX;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < minv)
 			py[i] = minv;

--- a/src/default/Compress.c
+++ b/src/default/Compress.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Compress(struct onnx_node_t * n)
 {

--- a/src/default/Concat.c
+++ b/src/default/Concat.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int axis;

--- a/src/default/ConcatFromSequence.c
+++ b/src/default/ConcatFromSequence.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ConcatFromSequence(struct onnx_node_t * n)
 {

--- a/src/default/Constant.c
+++ b/src/default/Constant.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Constant_init(struct onnx_node_t * n)
 {
@@ -59,7 +59,8 @@ static int Constant_init(struct onnx_node_t * n)
 					if(y->datas && attr->strings)
 					{
 						char ** str = (char **)y->datas;
-						for(size_t i = 0; i < y->ndata; i++)
+						size_t i;
+						for(i=0; i < y->ndata; i++)
 						{
 							if(str[i])
 							{
@@ -67,7 +68,8 @@ static int Constant_init(struct onnx_node_t * n)
 								str[i] = NULL;
 							}
 						}
-						for(size_t i = 0; i < y->ndata; i++)
+
+						for(i=0; i < y->ndata; i++)
 						{
 							str[i] = malloc(attr->strings[i].len + 1);
 							if(str[i])

--- a/src/default/ConstantOfShape.c
+++ b/src/default/ConstantOfShape.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 union onnx_scalar_t {
 	uint8_t v_bool;

--- a/src/default/ConvInteger.c
+++ b/src/default/ConvInteger.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ConvInteger(struct onnx_node_t * n)
 {

--- a/src/default/ConvTranspose.c
+++ b/src/default/ConvTranspose.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ConvTranspose(struct onnx_node_t * n)
 {

--- a/src/default/Cos.c
+++ b/src/default/Cos.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Cos_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Cos_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(cosf(v));
+		py[i] = float32_to_float16(cos(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Cos_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = cosf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = cos(px[i]);
 }
 
 static void Cos_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Cos_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = cos(px[i]);
 }
 

--- a/src/default/Cosh.c
+++ b/src/default/Cosh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Cosh_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Cosh_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(coshf(v));
+		py[i] = float32_to_float16(cosh(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Cosh_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = coshf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = cosh(px[i]);
 }
 
 static void Cosh_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Cosh_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = cosh(px[i]);
 }
 

--- a/src/default/CumSum.c
+++ b/src/default/CumSum.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_CumSum(struct onnx_node_t * n)
 {

--- a/src/default/DepthToSpace.c
+++ b/src/default/DepthToSpace.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_DepthToSpace(struct onnx_node_t * n)
 {

--- a/src/default/DequantizeLinear.c
+++ b/src/default/DequantizeLinear.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_DequantizeLinear(struct onnx_node_t * n)
 {

--- a/src/default/Det.c
+++ b/src/default/Det.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Det(struct onnx_node_t * n)
 {

--- a/src/default/Div.c
+++ b/src/default/Div.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Div_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Div_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Div_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Div_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Div_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Div_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Div_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Div_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Div_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Div_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Div_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Div_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Div_13_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Dropout.c
+++ b/src/default/Dropout.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Dropout_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,8 @@ static void Dropout_bfloat16(struct onnx_node_t * n)
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i];
 }
 
@@ -38,7 +39,8 @@ static void Dropout_float16(struct onnx_node_t * n)
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i];
 }
 
@@ -49,7 +51,8 @@ static void Dropout_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i];
 }
 
@@ -60,7 +63,8 @@ static void Dropout_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i];
 }
 

--- a/src/default/DynamicQuantizeLinear.c
+++ b/src/default/DynamicQuantizeLinear.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_DynamicQuantizeLinear(struct onnx_node_t * n)
 {

--- a/src/default/Einsum.c
+++ b/src/default/Einsum.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Einsum(struct onnx_node_t * n)
 {

--- a/src/default/Elu.c
+++ b/src/default/Elu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -47,10 +47,11 @@ static void Elu_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16((px[i] < 0) ? (expf(v) - 1) * pdat->alpha : v);
+		py[i] = float32_to_float16((px[i] < 0) ? (exp(v) - 1) * pdat->alpha : v);
 	}
 }
 
@@ -62,8 +63,9 @@ static void Elu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = (px[i] < 0) ? (expf(px[i]) - 1) * pdat->alpha : px[i];
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = (px[i] < 0) ? (exp(px[i]) - 1) * pdat->alpha : px[i];
 }
 
 static void Elu_float64(struct onnx_node_t * n)
@@ -74,7 +76,8 @@ static void Elu_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? (exp(px[i]) - 1) * pdat->alpha : px[i];
 }
 

--- a/src/default/Equal.c
+++ b/src/default/Equal.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Equal_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Equal_bool(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Equal_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Equal_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Equal_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Equal_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Equal_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Equal_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Equal_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Equal_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Equal_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Equal_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Equal_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -234,7 +246,8 @@ static void Equal_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Erf.c
+++ b/src/default/Erf.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Erf_init(struct onnx_node_t * n)
 {
@@ -124,7 +124,8 @@ static void Erf_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(erff(v));
@@ -139,7 +140,8 @@ static void Erf_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(erff(v));
@@ -153,7 +155,8 @@ static void Erf_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = erff(px[i]);
 }
 
@@ -164,7 +167,8 @@ static void Erf_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = erf(px[i]);
 }
 

--- a/src/default/Exp.c
+++ b/src/default/Exp.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Exp_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Exp_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
-		py[i] = float32_to_bfloat16(expf(v));
+		py[i] = float32_to_bfloat16(exp(v));
 	}
 }
 
@@ -43,10 +44,11 @@ static void Exp_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(expf(v));
+		py[i] = float32_to_float16(exp(v));
 	}
 }
 
@@ -57,8 +59,9 @@ static void Exp_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = expf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = exp(px[i]);
 }
 
 static void Exp_float64(struct onnx_node_t * n)
@@ -68,7 +71,8 @@ static void Exp_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = exp(px[i]);
 }
 

--- a/src/default/Expand.c
+++ b/src/default/Expand.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Expand_init(struct onnx_node_t * n)
 {
@@ -50,7 +50,8 @@ static void Expand_bool(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	uint8_t * px = (uint8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -64,7 +65,8 @@ static void Expand_int8(struct onnx_node_t * n)
 	int8_t * py = (int8_t *)y->datas;
 	int8_t * px = (int8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -78,7 +80,8 @@ static void Expand_int16(struct onnx_node_t * n)
 	int16_t * py = (int16_t *)y->datas;
 	int16_t * px = (int16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -92,7 +95,8 @@ static void Expand_int32(struct onnx_node_t * n)
 	int32_t * py = (int32_t *)y->datas;
 	int32_t * px = (int32_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -106,7 +110,8 @@ static void Expand_int64(struct onnx_node_t * n)
 	int64_t * py = (int64_t *)y->datas;
 	int64_t * px = (int64_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -120,7 +125,8 @@ static void Expand_uint8(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	uint8_t * px = (uint8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -134,7 +140,8 @@ static void Expand_uint16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -148,7 +155,8 @@ static void Expand_uint32(struct onnx_node_t * n)
 	uint32_t * py = (uint32_t *)y->datas;
 	uint32_t * px = (uint32_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -162,7 +170,8 @@ static void Expand_uint64(struct onnx_node_t * n)
 	uint64_t * py = (uint64_t *)y->datas;
 	uint64_t * px = (uint64_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -176,7 +185,8 @@ static void Expand_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -190,7 +200,8 @@ static void Expand_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -204,7 +215,8 @@ static void Expand_float32(struct onnx_node_t * n)
 	float * py = (float *)y->datas;
 	float * px = (float *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -218,7 +230,8 @@ static void Expand_float64(struct onnx_node_t * n)
 	double * py = (double *)y->datas;
 	double * px = (double *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -232,7 +245,8 @@ static void Expand_complex64(struct onnx_node_t * n)
 	float * py = (float *)y->datas;
 	float * px = (float *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i * 2] = px[0];
@@ -247,7 +261,8 @@ static void Expand_complex128(struct onnx_node_t * n)
 	double * py = (double *)y->datas;
 	double * px = (double *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i * 2] = px[0];
@@ -262,7 +277,8 @@ static void Expand_string(struct onnx_node_t * n)
 	char ** px = (char **)x->datas;
 	char ** py = (char **)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		if(py[i])

--- a/src/default/EyeLike.c
+++ b/src/default/EyeLike.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_EyeLike(struct onnx_node_t * n)
 {

--- a/src/default/Flatten.c
+++ b/src/default/Flatten.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int axis;
@@ -67,7 +67,8 @@ static void Flatten_operator(struct onnx_node_t * n)
 
 	if(x->type == ONNX_TENSOR_TYPE_STRING)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			if(py[i])
 				free(py[i]);

--- a/src/default/Floor.c
+++ b/src/default/Floor.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Floor_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Floor_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(floorf(v));
@@ -43,7 +44,8 @@ static void Floor_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(floorf(v));
@@ -57,7 +59,8 @@ static void Floor_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = floorf(px[i]);
 }
 
@@ -68,7 +71,8 @@ static void Floor_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = floor(px[i]);
 }
 

--- a/src/default/GRU.c
+++ b/src/default/GRU.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_GRU(struct onnx_node_t * n)
 {

--- a/src/default/Gather.c
+++ b/src/default/Gather.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Gather(struct onnx_node_t * n)
 {

--- a/src/default/GatherElements.c
+++ b/src/default/GatherElements.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_GatherElements(struct onnx_node_t * n)
 {

--- a/src/default/GatherND.c
+++ b/src/default/GatherND.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_GatherND(struct onnx_node_t * n)
 {

--- a/src/default/Gemm.c
+++ b/src/default/Gemm.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;

--- a/src/default/GlobalAveragePool.c
+++ b/src/default/GlobalAveragePool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int GlobalAveragePool_init(struct onnx_node_t * n)
 {

--- a/src/default/GlobalLpPool.c
+++ b/src/default/GlobalLpPool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float p;
@@ -70,8 +70,8 @@ static void GlobalLpPool_float16(struct onnx_node_t * n)
 		{
 			o = i * C + j;
 			for(k = 0, v = float16_to_float32(0); k < m; ++k)
-				v += powf(fabsf(float16_to_float32(px[o * m + k])), pdat->p);
-			py[o] = float32_to_float16(powf(v, 1.0 / pdat->p));
+				v += pow(fabsf(float16_to_float32(px[o * m + k])), pdat->p);
+			py[o] = float32_to_float16(pow(v, 1.0 / pdat->p));
 		}
 	}
 }
@@ -94,8 +94,8 @@ static void GlobalLpPool_float32(struct onnx_node_t * n)
 		{
 			o = i * C + j;
 			for(k = 0, py[o] = 0; k < m; ++k)
-				py[o] += powf(fabsf(px[o * m + k]), pdat->p);
-			py[o] = powf(py[o], 1.0 / pdat->p);
+				py[o] += pow(fabsf(px[o * m + k]), pdat->p);
+			py[o] = pow(py[o], 1.0 / pdat->p);
 		}
 	}
 }

--- a/src/default/GlobalMaxPool.c
+++ b/src/default/GlobalMaxPool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int GlobalMaxPool_init(struct onnx_node_t * n)
 {

--- a/src/default/Greater.c
+++ b/src/default/Greater.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Greater_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Greater_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Greater_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Greater_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Greater_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Greater_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Greater_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Greater_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Greater_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Greater_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Greater_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Greater_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Greater_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/GreaterOrEqual.c
+++ b/src/default/GreaterOrEqual.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int GreaterOrEqual_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void GreaterOrEqual_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void GreaterOrEqual_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void GreaterOrEqual_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void GreaterOrEqual_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void GreaterOrEqual_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void GreaterOrEqual_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void GreaterOrEqual_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void GreaterOrEqual_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void GreaterOrEqual_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void GreaterOrEqual_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void GreaterOrEqual_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/HardSigmoid.c
+++ b/src/default/HardSigmoid.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -49,7 +49,8 @@ static void HardSigmoid_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(max((float)0.0, min((float)1.0, (float)(pdat->alpha * v + pdat->beta))));
@@ -64,7 +65,8 @@ static void HardSigmoid_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = max((float)0.0, min((float)1.0, (float)(pdat->alpha * px[i] + pdat->beta)));
 }
 
@@ -76,7 +78,8 @@ static void HardSigmoid_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = max((double)0.0, min((double)1.0, (double)(pdat->alpha * px[i] + pdat->beta)));
 }
 

--- a/src/default/HardSwish.c
+++ b/src/default/HardSwish.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_HardSwish(struct onnx_node_t * n)
 {

--- a/src/default/Hardmax.c
+++ b/src/default/Hardmax.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Hardmax(struct onnx_node_t * n)
 {

--- a/src/default/Identity.c
+++ b/src/default/Identity.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Identity_init(struct onnx_node_t * n)
 {
@@ -29,7 +29,8 @@ static void Identity_operator(struct onnx_node_t * n)
 
 	if(x->type == ONNX_TENSOR_TYPE_STRING)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			if(py[i])
 				free(py[i]);

--- a/src/default/If.c
+++ b/src/default/If.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	struct onnx_graph_t * else_branch;
@@ -89,6 +89,8 @@ static void If_operator(struct onnx_node_t * n)
 	struct onnx_node_t * t;
 	int i;
 
+	size_t o;
+
 	if(px[0])
 		g = pdat->then_branch;
 	else
@@ -110,7 +112,7 @@ static void If_operator(struct onnx_node_t * n)
 				{
 					char ** pa = (char **)a->datas;
 					char ** pb = (char **)b->datas;
-					for(size_t o = 0; o < b->ndata; o++)
+					for(o = 0; o < b->ndata; o++)
 					{
 						if(pb[o])
 							free(pb[o]);

--- a/src/default/InstanceNormalization.c
+++ b/src/default/InstanceNormalization.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float epsilon;
@@ -107,7 +107,7 @@ static void InstanceNormalization_float32(struct onnx_node_t * n)
 		mean = temp / channel;
 		temp = 0;
 		for(i = o; i < l; i++)
-			temp += pow(px[i] - mean, 2);
+			temp += (px[i] - mean)*(px[i] - mean);
 		var = temp / channel;
 		for(i = o; i < l; i++)
 			py[i] = pscale[jc] * ((px[i] - mean) / sqrtf(var + pdat->epsilon)) + pb[jc];
@@ -145,7 +145,7 @@ static void InstanceNormalization_float64(struct onnx_node_t * n)
 		mean = temp / channel;
 		temp = 0;
 		for(i = o; i < l; i++)
-			temp += pow(px[i] - mean, 2);
+			temp += (px[i] - mean)*(px[i] - mean);
 		var = temp / channel;
 		for(i = o; i < l; i++)
 			py[i] = pscale[jc] * ((px[i] - mean) / sqrt(var + pdat->epsilon)) + pb[jc];

--- a/src/default/IsInf.c
+++ b/src/default/IsInf.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int detect_negative;
@@ -48,7 +48,8 @@ static void IsInf_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(isinf(px[i]))
 		{
@@ -72,7 +73,8 @@ static void IsInf_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(isinf(px[i]))
 		{

--- a/src/default/IsNaN.c
+++ b/src/default/IsNaN.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int IsNaN_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void IsNaN_bfloat16(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = isnan(v) ? 1 : 0;
@@ -43,7 +44,8 @@ static void IsNaN_float16(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = isnan(v) ? 1 : 0;
@@ -57,7 +59,8 @@ static void IsNaN_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = isnan(px[i]) ? 1 : 0;
 }
 
@@ -68,7 +71,8 @@ static void IsNaN_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = isnan(px[i]) ? 1 : 0;
 }
 

--- a/src/default/LRN.c
+++ b/src/default/LRN.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -77,7 +77,7 @@ static void LRN_bfloat16(struct onnx_node_t * n)
 					sum += t * t;
 				}
 				o = (u * C + v) * L + i;
-				py[o] = float32_to_bfloat16(bfloat16_to_float32(px[o]) * powf(pdat->bias + over * sum, -pdat->beta));
+				py[o] = float32_to_bfloat16(bfloat16_to_float32(px[o]) * pow(pdat->bias + over * sum, -pdat->beta));
 			}
 		}
 	}
@@ -116,7 +116,7 @@ static void LRN_float16(struct onnx_node_t * n)
 					sum += t * t;
 				}
 				o = (u * C + v) * L + i;
-				py[o] = float32_to_float16(float16_to_float32(px[o]) * powf(pdat->bias + over * sum, -pdat->beta));
+				py[o] = float32_to_float16(float16_to_float32(px[o]) * pow(pdat->bias + over * sum, -pdat->beta));
 			}
 		}
 	}
@@ -155,7 +155,7 @@ static void LRN_float32(struct onnx_node_t * n)
 					sum += t * t;
 				}
 				o = (u * C + v) * L + i;
-				py[o] = px[o] * powf(pdat->bias + over * sum, -pdat->beta);
+				py[o] = px[o] * pow(pdat->bias + over * sum, -pdat->beta);
 			}
 		}
 	}

--- a/src/default/LSTM.c
+++ b/src/default/LSTM.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_LSTM(struct onnx_node_t * n)
 {

--- a/src/default/LeakyRelu.c
+++ b/src/default/LeakyRelu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -47,7 +47,8 @@ static void LeakyRelu_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v < 0)
@@ -64,7 +65,8 @@ static void LeakyRelu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? px[i] * pdat->alpha : px[i];
 }
 
@@ -76,7 +78,8 @@ static void LeakyRelu_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? px[i] * pdat->alpha : px[i];
 }
 

--- a/src/default/Less.c
+++ b/src/default/Less.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Less_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Less_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Less_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Less_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Less_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Less_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Less_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Less_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Less_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Less_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Less_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Less_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Less_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/LessOrEqual.c
+++ b/src/default/LessOrEqual.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int LessOrEqual_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void LessOrEqual_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void LessOrEqual_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void LessOrEqual_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void LessOrEqual_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void LessOrEqual_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void LessOrEqual_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void LessOrEqual_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void LessOrEqual_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void LessOrEqual_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void LessOrEqual_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void LessOrEqual_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Log.c
+++ b/src/default/Log.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Log_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Log_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(logf(v));
@@ -43,7 +44,8 @@ static void Log_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(logf(v));
@@ -57,7 +59,8 @@ static void Log_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = logf(px[i]);
 }
 
@@ -68,7 +71,8 @@ static void Log_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = log(px[i]);
 }
 

--- a/src/default/LogSoftmax.c
+++ b/src/default/LogSoftmax.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_13_pdata_t
 {
@@ -86,7 +86,7 @@ static void LogSoftmax_13_bfloat16(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				v = expf(bfloat16_to_float32(px[o]) - maxv);
+				v = exp(bfloat16_to_float32(px[o]) - maxv);
 				py[o] = float32_to_bfloat16(v);
 				sum += v;
 			}
@@ -129,7 +129,7 @@ static void LogSoftmax_13_float16(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				v = expf(float16_to_float32(px[o]) - maxv);
+				v = exp(float16_to_float32(px[o]) - maxv);
 				py[o] = float32_to_float16(v);
 				sum += v;
 			}
@@ -171,7 +171,7 @@ static void LogSoftmax_13_float32(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				py[o] = expf(px[o] - maxv);
+				py[o] = exp(px[o] - maxv);
 				sum += py[o];
 			}
 			if(sum != 0)
@@ -301,7 +301,7 @@ static void LogSoftmax_1_11_float16(struct onnx_node_t * n)
 		}
 		for(j = 0, sum = 0; j < pdat->D; j++)
 		{
-			v = expf(float16_to_float32(px[o + j]) - maxv);
+			v = exp(float16_to_float32(px[o + j]) - maxv);
 			py[o + j] = float32_to_float16(v);
 			sum += v;
 		}
@@ -335,7 +335,7 @@ static void LogSoftmax_1_11_float32(struct onnx_node_t * n)
 		}
 		for(j = 0, sum = 0; j < pdat->D; j++)
 		{
-			py[o + j] = expf(px[o + j] - maxv);
+			py[o + j] = exp(px[o + j] - maxv);
 			sum += py[o + j];
 		}
 		if(sum != 0)

--- a/src/default/Loop.c
+++ b/src/default/Loop.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Loop(struct onnx_node_t * n)
 {

--- a/src/default/LpNormalization.c
+++ b/src/default/LpNormalization.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_LpNormalization(struct onnx_node_t * n)
 {

--- a/src/default/LpPool.c
+++ b/src/default/LpPool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_LpPool(struct onnx_node_t * n)
 {

--- a/src/default/MatMul.c
+++ b/src/default/MatMul.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int m;
@@ -73,7 +73,9 @@ static int MatMul_reshape(struct onnx_node_t * n)
 		return 0;
 	dims[ndim - 2] = adims[andim - 2];
 	dims[ndim - 1] = bdims[bndim - 1];
-	for(int i = 3; i <= ndim; i++)
+
+	int i;
+	for(i = 3; i <= ndim; i++)
 	{
 		int alen = (andim - i) < 0 ? 1 : adims[andim - i];
 		int blen = (bndim - i) < 0 ? 1 : bdims[bndim - i];
@@ -98,16 +100,18 @@ static void MatMul_int32(struct onnx_node_t * n)
 	int32_t * pb;
 	int32_t sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}
@@ -126,16 +130,18 @@ static void MatMul_int64(struct onnx_node_t * n)
 	int64_t * pb;
 	int64_t sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}
@@ -154,16 +160,18 @@ static void MatMul_uint32(struct onnx_node_t * n)
 	uint32_t * pb;
 	uint32_t sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}
@@ -182,16 +190,18 @@ static void MatMul_uint64(struct onnx_node_t * n)
 	uint64_t * pb;
 	uint64_t sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}
@@ -210,18 +220,20 @@ static void MatMul_bfloat16(struct onnx_node_t * n)
 	uint16_t * pb;
 	float sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
-					sum += bfloat16_to_float32(pa[u * pdat->k + w]) * bfloat16_to_float32(pb[w * pdat->n + v]);
-				py[i + u * pdat->n + v] = float32_to_bfloat16(sum);
+				for(w = 0; w < pdat->k; w++)
+					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
+				py[i + u * pdat->n + v] = sum;
 			}
 		}
 	}
@@ -238,18 +250,20 @@ static void MatMul_float16(struct onnx_node_t * n)
 	uint16_t * pb;
 	float sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
-					sum += float16_to_float32(pa[u * pdat->k + w]) * float16_to_float32(pb[w * pdat->n + v]);
-				py[i + u * pdat->n + v] = float32_to_float16(sum);
+				for(w = 0; w < pdat->k; w++)
+					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
+				py[i + u * pdat->n + v] = sum;
 			}
 		}
 	}
@@ -266,16 +280,18 @@ static void MatMul_float32(struct onnx_node_t * n)
 	float * pb;
 	float sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}
@@ -294,16 +310,18 @@ static void MatMul_float64(struct onnx_node_t * n)
 	double * pb;
 	double sum;
 
-	for(size_t i = 0, l = y->ndata; i < l; i += pdat->m * pdat->n)
+	size_t i, l;
+	int u, v, w;
+	for(i=0, l = y->ndata; i < l; i += pdat->m * pdat->n)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
-		for(int u = 0; u < pdat->m; u++)
+		for(u = 0; u < pdat->m; u++)
 		{
-			for(int v = 0; v < pdat->n; v++)
+			for(v = 0; v < pdat->n; v++)
 			{
 				sum = 0;
-				for(int w = 0; w < pdat->k; w++)
+				for(w = 0; w < pdat->k; w++)
 					sum += pa[u * pdat->k + w] * pb[w * pdat->n + v];
 				py[i + u * pdat->n + v] = sum;
 			}

--- a/src/default/MatMulInteger.c
+++ b/src/default/MatMulInteger.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_MatMulInteger(struct onnx_node_t * n)
 {

--- a/src/default/Max.c
+++ b/src/default/Max.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Max_init(struct onnx_node_t * n)
 {
@@ -35,10 +35,12 @@ static void Max_int8(struct onnx_node_t * n)
 	int8_t * px;
 	int8_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = INT8_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -57,10 +59,12 @@ static void Max_int16(struct onnx_node_t * n)
 	int16_t * px;
 	int16_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = INT16_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -79,10 +83,12 @@ static void Max_int32(struct onnx_node_t * n)
 	int32_t * px;
 	int32_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = INT32_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -101,10 +107,12 @@ static void Max_int64(struct onnx_node_t * n)
 	int64_t * px;
 	int64_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = INT64_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -123,10 +131,12 @@ static void Max_uint8(struct onnx_node_t * n)
 	uint8_t * px;
 	uint8_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = 0;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -145,10 +155,12 @@ static void Max_uint16(struct onnx_node_t * n)
 	uint16_t * px;
 	uint16_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = 0;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -167,10 +179,12 @@ static void Max_uint32(struct onnx_node_t * n)
 	uint32_t * px;
 	uint32_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = 0;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -189,10 +203,12 @@ static void Max_uint64(struct onnx_node_t * n)
 	uint64_t * px;
 	uint64_t maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = 0;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -212,10 +228,12 @@ static void Max_bfloat16(struct onnx_node_t * n)
 	float v;
 	float maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = FLT_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -236,10 +254,12 @@ static void Max_float16(struct onnx_node_t * n)
 	float v;
 	float maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = FLT_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -259,10 +279,12 @@ static void Max_float32(struct onnx_node_t * n)
 	float * px;
 	float maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = FLT_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);
@@ -281,10 +303,12 @@ static void Max_float64(struct onnx_node_t * n)
 	double * px;
 	double maxv;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	int j;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		maxv = DBL_MIN;
-		for(int j = 0; j < n->ninput; j++)
+		for(j = 0; j < n->ninput; j++)
 		{
 			x = n->inputs[j];
 			px = onnx_tensor_broadcast_map_address(x, y, i);

--- a/src/default/MaxPool.c
+++ b/src/default/MaxPool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 enum auto_pad_t {
 	AUTO_PAD_NOTSET		= 0,

--- a/src/default/MaxRoiPool.c
+++ b/src/default/MaxRoiPool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_MaxRoiPool(struct onnx_node_t * n)
 {

--- a/src/default/MaxUnpool.c
+++ b/src/default/MaxUnpool.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_MaxUnpool(struct onnx_node_t * n)
 {

--- a/src/default/Mean.c
+++ b/src/default/Mean.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Mean_init(struct onnx_node_t * n)
 {

--- a/src/default/MeanVarianceNormalization.c
+++ b/src/default/MeanVarianceNormalization.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_MeanVarianceNormalization(struct onnx_node_t * n)
 {

--- a/src/default/Min.c
+++ b/src/default/Min.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Min_init(struct onnx_node_t * n)
 {

--- a/src/default/Mod.c
+++ b/src/default/Mod.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int fmod;
@@ -52,7 +52,8 @@ static void Mod_int8(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -61,7 +62,8 @@ static void Mod_int8(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -86,7 +88,8 @@ static void Mod_int16(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -95,7 +98,8 @@ static void Mod_int16(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -120,7 +124,8 @@ static void Mod_int32(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -129,7 +134,8 @@ static void Mod_int32(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -154,7 +160,8 @@ static void Mod_int64(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -163,7 +170,8 @@ static void Mod_int64(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -187,7 +195,8 @@ static void Mod_uint8(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -196,7 +205,8 @@ static void Mod_uint8(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +227,8 @@ static void Mod_uint16(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -226,7 +237,8 @@ static void Mod_uint16(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -247,7 +259,8 @@ static void Mod_uint32(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -256,7 +269,8 @@ static void Mod_uint32(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -277,7 +291,8 @@ static void Mod_uint64(struct onnx_node_t * n)
 
 	if(pdat->fmod)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -286,7 +301,8 @@ static void Mod_uint64(struct onnx_node_t * n)
 	}
 	else
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			pa = onnx_tensor_broadcast_map_address(a, y, i);
 			pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -304,7 +320,8 @@ static void Mod_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -321,7 +338,8 @@ static void Mod_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -338,7 +356,8 @@ static void Mod_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -355,7 +374,8 @@ static void Mod_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Mul.c
+++ b/src/default/Mul.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Mul_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Mul_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Mul_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Mul_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Mul_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Mul_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Mul_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Mul_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Mul_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Mul_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Mul_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Mul_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Mul_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Multinomial.c
+++ b/src/default/Multinomial.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t dtype;

--- a/src/default/Neg.c
+++ b/src/default/Neg.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Neg_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,8 @@ static void Neg_int8(struct onnx_node_t * n)
 	int8_t * px = (int8_t *)x->datas;
 	int8_t * py = (int8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 
@@ -38,7 +39,8 @@ static void Neg_int16(struct onnx_node_t * n)
 	int16_t * px = (int16_t *)x->datas;
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 
@@ -49,7 +51,8 @@ static void Neg_int32(struct onnx_node_t * n)
 	int32_t * px = (int32_t *)x->datas;
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 
@@ -60,7 +63,8 @@ static void Neg_int64(struct onnx_node_t * n)
 	int64_t * px = (int64_t *)x->datas;
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 
@@ -72,7 +76,8 @@ static void Neg_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(-v);
@@ -87,7 +92,8 @@ static void Neg_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(-v);
@@ -101,7 +107,8 @@ static void Neg_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 
@@ -112,7 +119,8 @@ static void Neg_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = -px[i];
 }
 

--- a/src/default/NegativeLogLikelihoodLoss.c
+++ b/src/default/NegativeLogLikelihoodLoss.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_NegativeLogLikelihoodLoss(struct onnx_node_t * n)
 {

--- a/src/default/NonMaxSuppression.c
+++ b/src/default/NonMaxSuppression.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_NonMaxSuppression(struct onnx_node_t * n)
 {

--- a/src/default/NonZero.c
+++ b/src/default/NonZero.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_NonZero(struct onnx_node_t * n)
 {

--- a/src/default/Not.c
+++ b/src/default/Not.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Not_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,8 @@ static void Not_bool(struct onnx_node_t * n)
 	uint8_t * px = (uint8_t *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = !px[i];
 }
 

--- a/src/default/OneHot.c
+++ b/src/default/OneHot.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_OneHot(struct onnx_node_t * n)
 {

--- a/src/default/Or.c
+++ b/src/default/Or.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Or_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Or_bool(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/PRelu.c
+++ b/src/default/PRelu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int PRelu_init(struct onnx_node_t * n)
 {
@@ -29,7 +29,8 @@ static void PRelu_int32(struct onnx_node_t * n)
 	int32_t * pa = (int32_t *)a->datas;;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{
@@ -50,7 +51,8 @@ static void PRelu_int64(struct onnx_node_t * n)
 	int64_t * pa = (int64_t *)a->datas;;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{
@@ -71,7 +73,8 @@ static void PRelu_uint32(struct onnx_node_t * n)
 	uint32_t * pa = (uint32_t *)a->datas;;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{
@@ -92,7 +95,8 @@ static void PRelu_uint64(struct onnx_node_t * n)
 	uint64_t * pa = (uint64_t *)a->datas;;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{
@@ -114,7 +118,8 @@ static void PRelu_float16(struct onnx_node_t * n)
 	uint16_t * pb;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(pa[i]);
 		if(v < 0)
@@ -136,7 +141,8 @@ static void PRelu_float32(struct onnx_node_t * n)
 	float * pa = (float *)a->datas;;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{
@@ -157,7 +163,8 @@ static void PRelu_float64(struct onnx_node_t * n)
 	double * pa = (double *)a->datas;;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(pa[i] < 0)
 		{

--- a/src/default/Pad.c
+++ b/src/default/Pad.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Pad(struct onnx_node_t * n)
 {

--- a/src/default/Pow.c
+++ b/src/default/Pow.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Pow_init(struct onnx_node_t * n)
 {
@@ -83,7 +83,8 @@ static void Pow_int32(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -102,7 +103,8 @@ static void Pow_int64(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -121,7 +123,8 @@ static void Pow_bfloat16(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -140,7 +143,8 @@ static void Pow_float16(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -159,7 +163,8 @@ static void Pow_float32(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -178,7 +183,8 @@ static void Pow_float64(struct onnx_node_t * n)
 	void * pb;
 	double v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/QLinearConv.c
+++ b/src/default/QLinearConv.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_QLinearConv(struct onnx_node_t * n)
 {

--- a/src/default/QLinearMatMul.c
+++ b/src/default/QLinearMatMul.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_QLinearMatMul(struct onnx_node_t * n)
 {

--- a/src/default/QuantizeLinear.c
+++ b/src/default/QuantizeLinear.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_QuantizeLinear(struct onnx_node_t * n)
 {

--- a/src/default/RNN.c
+++ b/src/default/RNN.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_RNN(struct onnx_node_t * n)
 {

--- a/src/default/RandomNormal.c
+++ b/src/default/RandomNormal.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t dtype;
@@ -70,17 +70,21 @@ static void RandomNormal_operator(struct onnx_node_t * n)
 
 	if(pdat->seed != 0.0)
 		srand(pdat->seed);
+
+	size_t i, l;
+
 	switch(pdat->dtype)
 	{
 	case ONNX_TENSOR_TYPE_FLOAT16:
 		{
 			uint16_t * py = (uint16_t *)y->datas;
 			float ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (float)rand() / (RAND_MAX + 1.0f);
 				tx = (float)rand() / (RAND_MAX + 1.0f);
-				py[i] = float16_to_float32(pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cosf(2.0f * acosf(-1.0f) * ty));
+				py[i] = float16_to_float32(pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cos(2.0f * acos(-1.0f) * ty));
 			}
 		}
 		break;
@@ -88,11 +92,12 @@ static void RandomNormal_operator(struct onnx_node_t * n)
 		{
 			float * py = (float *)y->datas;
 			float ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (float)rand() / (RAND_MAX + 1.0f);
 				tx = (float)rand() / (RAND_MAX + 1.0f);
-				py[i] = pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cosf(2.0f * acosf(-1.0f) * ty);
+				py[i] = pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cos(2.0f * acos(-1.0f) * ty);
 			}
 		}
 		break;
@@ -100,7 +105,8 @@ static void RandomNormal_operator(struct onnx_node_t * n)
 		{
 			double * py = (double *)y->datas;
 			double ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (double)rand() / (RAND_MAX + 1.0f);
 				tx = (double)rand() / (RAND_MAX + 1.0f);

--- a/src/default/RandomNormalLike.c
+++ b/src/default/RandomNormalLike.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t dtype;
@@ -66,17 +66,21 @@ static void RandomNormalLike_operator(struct onnx_node_t * n)
 
 	if(pdat->seed != 0.0)
 		srand(pdat->seed);
+
+	size_t i, l;
+
 	switch(pdat->dtype)
 	{
 	case ONNX_TENSOR_TYPE_FLOAT16:
 		{
 			uint16_t * py = (uint16_t *)y->datas;
 			float ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (float)rand() / (RAND_MAX + 1.0f);
 				tx = (float)rand() / (RAND_MAX + 1.0f);
-				py[i] = float16_to_float32(pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cosf(2.0f * acosf(-1.0f) * ty));
+				py[i] = float16_to_float32(pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cos(2.0f * acos(-1.0f) * ty));
 			}
 		}
 		break;
@@ -84,11 +88,12 @@ static void RandomNormalLike_operator(struct onnx_node_t * n)
 		{
 			float * py = (float *)y->datas;
 			float ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (float)rand() / (RAND_MAX + 1.0f);
 				tx = (float)rand() / (RAND_MAX + 1.0f);
-				py[i] = pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cosf(2.0f * acosf(-1.0f) * ty);
+				py[i] = pdat->mean + pdat->scale * sqrtf(-2.0f * logf(tx)) * cos(2.0f * acos(-1.0f) * ty);
 			}
 		}
 		break;
@@ -96,7 +101,8 @@ static void RandomNormalLike_operator(struct onnx_node_t * n)
 		{
 			double * py = (double *)y->datas;
 			double ty, tx;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 			{
 				ty = (double)rand() / (RAND_MAX + 1.0f);
 				tx = (double)rand() / (RAND_MAX + 1.0f);

--- a/src/default/RandomUniform.c
+++ b/src/default/RandomUniform.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t dtype;
@@ -70,26 +70,29 @@ static void RandomUniform_operator(struct onnx_node_t * n)
 
 	if(pdat->seed != 0.0)
 		srand(pdat->seed);
+
+	size_t i, l;
+
 	switch(pdat->dtype)
 	{
 	case ONNX_TENSOR_TYPE_FLOAT16:
 		{
 			uint16_t * py = (uint16_t *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = float16_to_float32(((float)rand() / (float)RAND_MAX) * (pdat->high - pdat->low) + pdat->low);
 		}
 		break;
 	case ONNX_TENSOR_TYPE_FLOAT32:
 		{
 			float * py = (float *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = ((float)rand() / (float)RAND_MAX) * (pdat->high - pdat->low) + pdat->low;
 		}
 		break;
 	case ONNX_TENSOR_TYPE_FLOAT64:
 		{
 			double * py = (double *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = ((double)rand() / (double)RAND_MAX) * (pdat->high - pdat->low) + pdat->low;
 		}
 		break;

--- a/src/default/RandomUniformLike.c
+++ b/src/default/RandomUniformLike.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	enum onnx_tensor_type_t dtype;
@@ -66,26 +66,32 @@ static void RandomUniformLike_operator(struct onnx_node_t * n)
 
 	if(pdat->seed != 0.0)
 		srand(pdat->seed);
+
+	size_t i, l;
+
 	switch(pdat->dtype)
 	{
 	case ONNX_TENSOR_TYPE_FLOAT16:
 		{
 			uint16_t * py = (uint16_t *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = float16_to_float32(((float)rand() / (float)RAND_MAX) * (pdat->high - pdat->low) + pdat->low);
 		}
 		break;
 	case ONNX_TENSOR_TYPE_FLOAT32:
 		{
 			float * py = (float *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = ((float)rand() / (float)RAND_MAX) * (pdat->high - pdat->low) + pdat->low;
 		}
 		break;
 	case ONNX_TENSOR_TYPE_FLOAT64:
 		{
 			double * py = (double *)y->datas;
-			for(size_t i = 0, l = y->ndata; i < l; i++)
+
+			for(i = 0, l = y->ndata; i < l; i++)
 				py[i] = ((double)rand() / (double)RAND_MAX) * (pdat->high - pdat->low) + pdat->low;
 		}
 		break;

--- a/src/default/Range.c
+++ b/src/default/Range.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	double start;
@@ -105,7 +105,8 @@ static void Range_int16(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = pdat->start + (pdat->delta * i);
 }
 
@@ -115,7 +116,8 @@ static void Range_int32(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = pdat->start + (pdat->delta * i);
 }
 
@@ -125,7 +127,8 @@ static void Range_int64(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = pdat->start + (pdat->delta * i);
 }
 
@@ -135,7 +138,8 @@ static void Range_float32(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = pdat->start + (pdat->delta * i);
 }
 
@@ -145,7 +149,8 @@ static void Range_float64(struct onnx_node_t * n)
 	struct onnx_tensor_t * y = n->outputs[0];
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = pdat->start + (pdat->delta * i);
 }
 

--- a/src/default/Reciprocal.c
+++ b/src/default/Reciprocal.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Reciprocal_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Reciprocal_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(1.0 / v);
@@ -43,7 +44,8 @@ static void Reciprocal_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(1.0 / v);
@@ -57,7 +59,8 @@ static void Reciprocal_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = 1.0 / px[i];
 }
 
@@ -68,7 +71,8 @@ static void Reciprocal_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = 1.0 / px[i];
 }
 

--- a/src/default/ReduceL1.c
+++ b/src/default/ReduceL1.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceL2.c
+++ b/src/default/ReduceL2.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceLogSum.c
+++ b/src/default/ReduceLogSum.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceLogSumExp.c
+++ b/src/default/ReduceLogSumExp.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;
@@ -187,7 +187,7 @@ static void ReduceLogSumExp_int8(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -235,7 +235,7 @@ static void ReduceLogSumExp_int32(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -283,7 +283,7 @@ static void ReduceLogSumExp_int64(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -331,7 +331,7 @@ static void ReduceLogSumExp_uint8(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -379,7 +379,7 @@ static void ReduceLogSumExp_uint32(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -427,7 +427,7 @@ static void ReduceLogSumExp_uint64(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -475,7 +475,7 @@ static void ReduceLogSumExp_bfloat16(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(bfloat16_to_float32(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]));
+			sum += exp(bfloat16_to_float32(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]));
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = float32_to_bfloat16(logf(sum));
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -523,7 +523,7 @@ static void ReduceLogSumExp_float16(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(float16_to_float32(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]));
+			sum += exp(float16_to_float32(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]));
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = float32_to_float16(logf(sum));
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));
@@ -571,7 +571,7 @@ static void ReduceLogSumExp_float32(struct onnx_node_t * n)
 		sum = 0;
 		do
 		{
-			sum += expf(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
+			sum += exp(px[o + dim_offset(pdat->naxes, iter_in_axes, in_axes_axis_dis)]);
 		} while(dim_next(pdat->naxes, iter_in_axes, iter_in_axes_max));
 		py[i++] = logf(sum);
 	} while(dim_next(not_in_axes_num, iter_not_in_axes, iter_not_in_axes_max));

--- a/src/default/ReduceMax.c
+++ b/src/default/ReduceMax.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceMean.c
+++ b/src/default/ReduceMean.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceMin.c
+++ b/src/default/ReduceMin.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceProd.c
+++ b/src/default/ReduceProd.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/ReduceSum.c
+++ b/src/default/ReduceSum.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int keepdims;

--- a/src/default/ReduceSumSquare.c
+++ b/src/default/ReduceSumSquare.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * axes;

--- a/src/default/Relu.c
+++ b/src/default/Relu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Relu_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,8 @@ static void Relu_int8(struct onnx_node_t * n)
 	int8_t * px = (int8_t *)x->datas;
 	int8_t * py = (int8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 
@@ -38,7 +39,8 @@ static void Relu_int16(struct onnx_node_t * n)
 	int16_t * px = (int16_t *)x->datas;
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 
@@ -49,7 +51,8 @@ static void Relu_int32(struct onnx_node_t * n)
 	int32_t * px = (int32_t *)x->datas;
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 
@@ -60,7 +63,8 @@ static void Relu_int64(struct onnx_node_t * n)
 	int64_t * px = (int64_t *)x->datas;
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 
@@ -72,7 +76,8 @@ static void Relu_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		if(v < 0)
@@ -89,7 +94,8 @@ static void Relu_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v < 0)
@@ -105,7 +111,8 @@ static void Relu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 
@@ -116,7 +123,8 @@ static void Relu_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] < 0) ? 0 : px[i];
 }
 

--- a/src/default/Reshape.c
+++ b/src/default/Reshape.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Reshape_init(struct onnx_node_t * n)
 {
@@ -34,7 +34,9 @@ static int Reshape_reshape(struct onnx_node_t * n)
 	int ndim = s->ndata;
 	int dims[ndim];
 
-	for(int i = 0; i < ndim; i++)
+	int i, j;
+
+	for(i = 0; i < ndim; i++)
 	{
 		if(ps[i] == 0)
 			dims[i] = x->dims[i];
@@ -42,9 +44,9 @@ static int Reshape_reshape(struct onnx_node_t * n)
 			dims[i] = ps[i];
 		else
 		{
-			for(int j = 0; j < x->ndim; j++)
+			for(j = 0; j < x->ndim; j++)
 				total_dim *= x->dims[j];
-			for(int j = 0; j < ndim; j++)
+			for(j = 0; j < ndim; j++)
 			{
 				if(ps[j] > 0)
 					total_shape *= ps[j];
@@ -66,7 +68,8 @@ static void Reshape_operator(struct onnx_node_t * n)
 
 	if(x->type == ONNX_TENSOR_TYPE_STRING)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			if(py[i])
 				free(py[i]);

--- a/src/default/Resize.c
+++ b/src/default/Resize.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Resize(struct onnx_node_t * n)
 {

--- a/src/default/ReverseSequence.c
+++ b/src/default/ReverseSequence.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ReverseSequence(struct onnx_node_t * n)
 {

--- a/src/default/RoiAlign.c
+++ b/src/default/RoiAlign.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_RoiAlign(struct onnx_node_t * n)
 {

--- a/src/default/Round.c
+++ b/src/default/Round.c
@@ -1,5 +1,5 @@
 #include <fenv.h>
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Round_init(struct onnx_node_t * n)
 {
@@ -33,7 +33,8 @@ static void Round_float16(struct onnx_node_t * n)
 	}
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(nearbyintf(v));
@@ -55,7 +56,8 @@ static void Round_float32(struct onnx_node_t * n)
 		fesetround(FE_TONEAREST);
 	}
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = nearbyintf(px[i]);
 
 	if (r != FE_TONEAREST) {
@@ -74,7 +76,8 @@ static void Round_float64(struct onnx_node_t * n)
 		fesetround(FE_TONEAREST);
 	}
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = nearbyint(px[i]);
 
 	if (r != FE_TONEAREST) {

--- a/src/default/Scan.c
+++ b/src/default/Scan.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Scan(struct onnx_node_t * n)
 {

--- a/src/default/Scatter.c
+++ b/src/default/Scatter.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Scatter(struct onnx_node_t * n)
 {

--- a/src/default/ScatterElements.c
+++ b/src/default/ScatterElements.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ScatterElements(struct onnx_node_t * n)
 {

--- a/src/default/ScatterND.c
+++ b/src/default/ScatterND.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_ScatterND(struct onnx_node_t * n)
 {

--- a/src/default/Selu.c
+++ b/src/default/Selu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -49,13 +49,14 @@ static void Selu_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v > 0)
 			py[i] = pdat->gamma * v;
 		else
-			py[i] = pdat->gamma * (pdat->alpha * expf(v) - pdat->alpha);
+			py[i] = pdat->gamma * (pdat->alpha * exp(v) - pdat->alpha);
 	}
 }
 
@@ -67,12 +68,13 @@ static void Selu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = pdat->gamma * px[i];
 		else
-			py[i] = pdat->gamma * (pdat->alpha * expf(px[i]) - pdat->alpha);
+			py[i] = pdat->gamma * (pdat->alpha * exp(px[i]) - pdat->alpha);
 	}
 }
 
@@ -84,7 +86,8 @@ static void Selu_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = pdat->gamma * px[i];

--- a/src/default/SequenceAt.c
+++ b/src/default/SequenceAt.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceAt(struct onnx_node_t * n)
 {

--- a/src/default/SequenceConstruct.c
+++ b/src/default/SequenceConstruct.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceConstruct(struct onnx_node_t * n)
 {

--- a/src/default/SequenceEmpty.c
+++ b/src/default/SequenceEmpty.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceEmpty(struct onnx_node_t * n)
 {

--- a/src/default/SequenceErase.c
+++ b/src/default/SequenceErase.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceErase(struct onnx_node_t * n)
 {

--- a/src/default/SequenceInsert.c
+++ b/src/default/SequenceInsert.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceInsert(struct onnx_node_t * n)
 {

--- a/src/default/SequenceLength.c
+++ b/src/default/SequenceLength.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SequenceLength(struct onnx_node_t * n)
 {

--- a/src/default/Shape.c
+++ b/src/default/Shape.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Shape_init(struct onnx_node_t * n)
 {

--- a/src/default/Shrink.c
+++ b/src/default/Shrink.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float bias;
@@ -48,7 +48,8 @@ static void Shrink_int8(struct onnx_node_t * n)
 	int8_t * px = (int8_t *)x->datas;
 	int8_t * py = (int8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -67,7 +68,8 @@ static void Shrink_int16(struct onnx_node_t * n)
 	int16_t * px = (int16_t *)x->datas;
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -86,7 +88,8 @@ static void Shrink_int32(struct onnx_node_t * n)
 	int32_t * px = (int32_t *)x->datas;
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -105,7 +108,8 @@ static void Shrink_int64(struct onnx_node_t * n)
 	int64_t * px = (int64_t *)x->datas;
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -124,7 +128,8 @@ static void Shrink_uint8(struct onnx_node_t * n)
 	uint8_t * px = (uint8_t *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -143,7 +148,8 @@ static void Shrink_uint16(struct onnx_node_t * n)
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -162,7 +168,8 @@ static void Shrink_uint32(struct onnx_node_t * n)
 	uint32_t * px = (uint32_t *)x->datas;
 	uint32_t * py = (uint32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -181,7 +188,8 @@ static void Shrink_uint64(struct onnx_node_t * n)
 	uint64_t * px = (uint64_t *)x->datas;
 	uint64_t * py = (uint64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -201,7 +209,8 @@ static void Shrink_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v < -pdat->lambd)
@@ -221,7 +230,8 @@ static void Shrink_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;
@@ -240,7 +250,8 @@ static void Shrink_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] < -pdat->lambd)
 			py[i] = px[i] + pdat->bias;

--- a/src/default/Sigmoid.c
+++ b/src/default/Sigmoid.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sigmoid_init(struct onnx_node_t * n)
 {
@@ -28,13 +28,14 @@ static void Sigmoid_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		if(v >= 0)
-			py[i] = float32_to_bfloat16(1.0 / (1.0 + expf(-1 * v)));
+			py[i] = float32_to_bfloat16(1.0 / (1.0 + exp(-1 * v)));
 		else
-			py[i] = float32_to_bfloat16(expf(v) / (1.0 + expf(v)));
+			py[i] = float32_to_bfloat16(exp(v) / (1.0 + exp(v)));
 	}
 }
 
@@ -46,13 +47,14 @@ static void Sigmoid_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v >= 0)
-			py[i] = float32_to_float16(1.0 / (1.0 + expf(-1 * v)));
+			py[i] = float32_to_float16(1.0 / (1.0 + exp(-1 * v)));
 		else
-			py[i] = float32_to_float16(expf(v) / (1.0 + expf(v)));
+			py[i] = float32_to_float16(exp(v) / (1.0 + exp(v)));
 	}
 }
 
@@ -63,12 +65,13 @@ static void Sigmoid_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] >= 0)
-			py[i] = 1.0 / (1.0 + expf(-1 * px[i]));
+			py[i] = 1.0 / (1.0 + exp(-1 * px[i]));
 		else
-			py[i] = expf(px[i]) / (1.0 + expf(px[i]));
+			py[i] = exp(px[i]) / (1.0 + exp(px[i]));
 	}
 }
 
@@ -79,7 +82,8 @@ static void Sigmoid_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] >= 0)
 			py[i] = 1.0 / (1.0 + exp(-1 * px[i]));

--- a/src/default/Sign.c
+++ b/src/default/Sign.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sign_init(struct onnx_node_t * n)
 {
@@ -27,7 +27,8 @@ static void Sign_int8(struct onnx_node_t * n)
 	int8_t * px = (int8_t *)x->datas;
 	int8_t * py = (int8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -45,7 +46,8 @@ static void Sign_int16(struct onnx_node_t * n)
 	int16_t * px = (int16_t *)x->datas;
 	int16_t * py = (int16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -63,7 +65,8 @@ static void Sign_int32(struct onnx_node_t * n)
 	int32_t * px = (int32_t *)x->datas;
 	int32_t * py = (int32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -81,7 +84,8 @@ static void Sign_int64(struct onnx_node_t * n)
 	int64_t * px = (int64_t *)x->datas;
 	int64_t * py = (int64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -99,7 +103,8 @@ static void Sign_uint8(struct onnx_node_t * n)
 	uint8_t * px = (uint8_t *)x->datas;
 	uint8_t * py = (uint8_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -117,7 +122,8 @@ static void Sign_uint16(struct onnx_node_t * n)
 	uint16_t * px = (uint16_t *)x->datas;
 	uint16_t * py = (uint16_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -135,7 +141,8 @@ static void Sign_uint32(struct onnx_node_t * n)
 	uint32_t * px = (uint32_t *)x->datas;
 	uint32_t * py = (uint32_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -153,7 +160,8 @@ static void Sign_uint64(struct onnx_node_t * n)
 	uint64_t * px = (uint64_t *)x->datas;
 	uint64_t * py = (uint64_t *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -172,7 +180,8 @@ static void Sign_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		if(v > 0)
@@ -192,7 +201,8 @@ static void Sign_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		if(v > 0)
@@ -211,7 +221,8 @@ static void Sign_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;
@@ -229,7 +240,8 @@ static void Sign_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		if(px[i] > 0)
 			py[i] = 1;

--- a/src/default/Sin.c
+++ b/src/default/Sin.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sin_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Sin_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(sinf(v));
+		py[i] = float32_to_float16(sin(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Sin_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = sinf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = sin(px[i]);
 }
 
 static void Sin_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Sin_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = sin(px[i]);
 }
 

--- a/src/default/Sinh.c
+++ b/src/default/Sinh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sinh_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Sinh_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(sinhf(v));
+		py[i] = float32_to_float16(sinh(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Sinh_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = sinhf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = sinh(px[i]);
 }
 
 static void Sinh_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Sinh_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = sinh(px[i]);
 }
 

--- a/src/default/Size.c
+++ b/src/default/Size.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Size_init(struct onnx_node_t * n)
 {

--- a/src/default/Slice.c
+++ b/src/default/Slice.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Slice(struct onnx_node_t * n)
 {

--- a/src/default/Softmax.c
+++ b/src/default/Softmax.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_13_pdata_t
 {
@@ -86,7 +86,7 @@ static void Softmax_13_bfloat16(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				v = expf(bfloat16_to_float32(px[o]) - maxv);
+				v = exp(bfloat16_to_float32(px[o]) - maxv);
 				py[o] = float32_to_bfloat16(v);
 				sum += v;
 			}
@@ -129,7 +129,7 @@ static void Softmax_13_float16(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				v = expf(float16_to_float32(px[o]) - maxv);
+				v = exp(float16_to_float32(px[o]) - maxv);
 				py[o] = float32_to_float16(v);
 				sum += v;
 			}
@@ -171,7 +171,7 @@ static void Softmax_13_float32(struct onnx_node_t * n)
 			for(j = 0, sum = 0; j < pdat->current; j++)
 			{
 				o = io + j * pdat->inner;
-				py[o] = expf(px[o] - maxv);
+				py[o] = exp(px[o] - maxv);
 				sum += py[o];
 			}
 			if(sum != 0)
@@ -301,7 +301,7 @@ static void Softmax_1_11_float16(struct onnx_node_t * n)
 		}
 		for(j = 0, sum = 0; j < pdat->D; j++)
 		{
-			v = expf(float16_to_float32(px[o + j]) - maxv);
+			v = exp(float16_to_float32(px[o + j]) - maxv);
 			py[o + j] = float32_to_float16(v);
 			sum += v;
 		}
@@ -335,7 +335,7 @@ static void Softmax_1_11_float32(struct onnx_node_t * n)
 		}
 		for(j = 0, sum = 0; j < pdat->D; j++)
 		{
-			py[o + j] = expf(px[o + j] - maxv);
+			py[o + j] = exp(px[o + j] - maxv);
 			sum += py[o + j];
 		}
 		if(sum != 0)

--- a/src/default/SoftmaxCrossEntropyLoss.c
+++ b/src/default/SoftmaxCrossEntropyLoss.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SoftmaxCrossEntropyLoss(struct onnx_node_t * n)
 {

--- a/src/default/Softplus.c
+++ b/src/default/Softplus.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Softplus_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Softplus_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(logf(expf(v) + 1));
+		py[i] = float32_to_float16(logf(exp(v) + 1));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Softplus_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = logf(expf(px[i]) + 1);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = logf(exp(px[i]) + 1);
 }
 
 static void Softplus_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Softplus_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = log(exp(px[i]) + 1);
 }
 

--- a/src/default/Softsign.c
+++ b/src/default/Softsign.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Softsign_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Softsign_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(v / (1 + fabsf(v)));
@@ -42,7 +43,8 @@ static void Softsign_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i] / (1 + fabsf(px[i]));
 }
 
@@ -53,7 +55,8 @@ static void Softsign_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = px[i] / (1 + fabs(px[i]));
 }
 

--- a/src/default/SpaceToDepth.c
+++ b/src/default/SpaceToDepth.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SpaceToDepth(struct onnx_node_t * n)
 {

--- a/src/default/Split.c
+++ b/src/default/Split.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Split(struct onnx_node_t * n)
 {

--- a/src/default/SplitToSequence.c
+++ b/src/default/SplitToSequence.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_SplitToSequence(struct onnx_node_t * n)
 {

--- a/src/default/Sqrt.c
+++ b/src/default/Sqrt.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sqrt_init(struct onnx_node_t * n)
 {
@@ -28,7 +28,8 @@ static void Sqrt_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
 		py[i] = float32_to_bfloat16(sqrtf(v));
@@ -43,7 +44,8 @@ static void Sqrt_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = float32_to_float16(sqrtf(v));
@@ -57,7 +59,8 @@ static void Sqrt_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = sqrtf(px[i]);
 }
 
@@ -68,7 +71,8 @@ static void Sqrt_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = sqrt(px[i]);
 }
 

--- a/src/default/Squeeze.c
+++ b/src/default/Squeeze.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Squeeze_init(struct onnx_node_t * n)
 {
@@ -69,7 +69,8 @@ static void Squeeze_operator(struct onnx_node_t * n)
 
 	if(x->type == ONNX_TENSOR_TYPE_STRING)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			if(py[i])
 				free(py[i]);

--- a/src/default/StringNormalizer.c
+++ b/src/default/StringNormalizer.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_StringNormalizer(struct onnx_node_t * n)
 {

--- a/src/default/Sub.c
+++ b/src/default/Sub.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sub_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Sub_int8(struct onnx_node_t * n)
 	int8_t * pa;
 	int8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -47,7 +48,8 @@ static void Sub_int16(struct onnx_node_t * n)
 	int16_t * pa;
 	int16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -64,7 +66,8 @@ static void Sub_int32(struct onnx_node_t * n)
 	int32_t * pa;
 	int32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -81,7 +84,8 @@ static void Sub_int64(struct onnx_node_t * n)
 	int64_t * pa;
 	int64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -98,7 +102,8 @@ static void Sub_uint8(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -115,7 +120,8 @@ static void Sub_uint16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -132,7 +138,8 @@ static void Sub_uint32(struct onnx_node_t * n)
 	uint32_t * pa;
 	uint32_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -149,7 +156,8 @@ static void Sub_uint64(struct onnx_node_t * n)
 	uint64_t * pa;
 	uint64_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -166,7 +174,8 @@ static void Sub_bfloat16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -183,7 +192,8 @@ static void Sub_float16(struct onnx_node_t * n)
 	uint16_t * pa;
 	uint16_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -200,7 +210,8 @@ static void Sub_float32(struct onnx_node_t * n)
 	float * pa;
 	float * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);
@@ -217,7 +228,8 @@ static void Sub_float64(struct onnx_node_t * n)
 	double * pa;
 	double * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/Sum.c
+++ b/src/default/Sum.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Sum_init(struct onnx_node_t * n)
 {
@@ -36,7 +36,8 @@ static void Sum_bfloat16(struct onnx_node_t * n)
 	float sum;
 	int j;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		for(j = 0, sum = 0; j < n->ninput; j++)
 		{
@@ -57,7 +58,8 @@ static void Sum_float16(struct onnx_node_t * n)
 	float sum;
 	int j;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		for(j = 0, sum = 0; j < n->ninput; j++)
 		{
@@ -78,7 +80,8 @@ static void Sum_float32(struct onnx_node_t * n)
 	float sum;
 	int j;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		for(j = 0, sum = 0; j < n->ninput; j++)
 		{
@@ -99,7 +102,8 @@ static void Sum_float64(struct onnx_node_t * n)
 	double sum;
 	int j;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		for(j = 0, sum = 0; j < n->ninput; j++)
 		{

--- a/src/default/Tan.c
+++ b/src/default/Tan.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Tan_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Tan_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(tanf(v));
+		py[i] = float32_to_float16(tan(v));
 	}
 }
 
@@ -42,8 +43,9 @@ static void Tan_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = tanf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = tan(px[i]);
 }
 
 static void Tan_float64(struct onnx_node_t * n)
@@ -53,7 +55,8 @@ static void Tan_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = tan(px[i]);
 }
 

--- a/src/default/Tanh.c
+++ b/src/default/Tanh.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Tanh_init(struct onnx_node_t * n)
 {
@@ -28,10 +28,11 @@ static void Tanh_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = bfloat16_to_float32(px[i]);
-		py[i] = float32_to_bfloat16(tanhf(v));
+		py[i] = float32_to_bfloat16(tanh(v));
 	}
 }
 
@@ -43,10 +44,11 @@ static void Tanh_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
-		py[i] = float32_to_float16(tanhf(v));
+		py[i] = float32_to_float16(tanh(v));
 	}
 }
 
@@ -57,8 +59,9 @@ static void Tanh_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
-		py[i] = tanhf(px[i]);
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
+		py[i] = tanh(px[i]);
 }
 
 static void Tanh_float64(struct onnx_node_t * n)
@@ -68,7 +71,8 @@ static void Tanh_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = tanh(px[i]);
 }
 

--- a/src/default/TfIdfVectorizer.c
+++ b/src/default/TfIdfVectorizer.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_TfIdfVectorizer(struct onnx_node_t * n)
 {

--- a/src/default/ThresholdedRelu.c
+++ b/src/default/ThresholdedRelu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	float alpha;
@@ -47,7 +47,8 @@ static void ThresholdedRelu_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	float v;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		v = float16_to_float32(px[i]);
 		py[i] = (v > pdat->alpha) ? float32_to_float16(v) : 0;
@@ -62,7 +63,8 @@ static void ThresholdedRelu_float32(struct onnx_node_t * n)
 	float * px = (float *)x->datas;
 	float * py = (float *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] > pdat->alpha) ? px[i] : 0;
 }
 
@@ -74,7 +76,8 @@ static void ThresholdedRelu_float64(struct onnx_node_t * n)
 	double * px = (double *)x->datas;
 	double * py = (double *)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 		py[i] = (px[i] > pdat->alpha) ? px[i] : 0;
 }
 

--- a/src/default/Tile.c
+++ b/src/default/Tile.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Tile_init(struct onnx_node_t * n)
 {
@@ -34,7 +34,8 @@ static void Tile_bool(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	uint8_t * px = (uint8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -48,7 +49,8 @@ static void Tile_int8(struct onnx_node_t * n)
 	int8_t * py = (int8_t *)y->datas;
 	int8_t * px = (int8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -62,7 +64,8 @@ static void Tile_int16(struct onnx_node_t * n)
 	int16_t * py = (int16_t *)y->datas;
 	int16_t * px = (int16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -76,7 +79,8 @@ static void Tile_int32(struct onnx_node_t * n)
 	int32_t * py = (int32_t *)y->datas;
 	int32_t * px = (int32_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -90,7 +94,8 @@ static void Tile_int64(struct onnx_node_t * n)
 	int64_t * py = (int64_t *)y->datas;
 	int64_t * px = (int64_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -104,7 +109,8 @@ static void Tile_uint8(struct onnx_node_t * n)
 	uint8_t * py = (uint8_t *)y->datas;
 	uint8_t * px = (uint8_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -118,7 +124,8 @@ static void Tile_uint16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -132,7 +139,8 @@ static void Tile_uint32(struct onnx_node_t * n)
 	uint32_t * py = (uint32_t *)y->datas;
 	uint32_t * px = (uint32_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -146,7 +154,8 @@ static void Tile_uint64(struct onnx_node_t * n)
 	uint64_t * py = (uint64_t *)y->datas;
 	uint64_t * px = (uint64_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -160,7 +169,8 @@ static void Tile_bfloat16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -174,7 +184,8 @@ static void Tile_float16(struct onnx_node_t * n)
 	uint16_t * py = (uint16_t *)y->datas;
 	uint16_t * px = (uint16_t *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -188,7 +199,8 @@ static void Tile_float32(struct onnx_node_t * n)
 	float * py = (float *)y->datas;
 	float * px = (float *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -202,7 +214,8 @@ static void Tile_float64(struct onnx_node_t * n)
 	double * py = (double *)y->datas;
 	double * px = (double *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i] = *px;
@@ -216,7 +229,8 @@ static void Tile_complex64(struct onnx_node_t * n)
 	float * py = (float *)y->datas;
 	float * px = (float *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i * 2] = px[0];
@@ -231,7 +245,8 @@ static void Tile_complex128(struct onnx_node_t * n)
 	double * py = (double *)y->datas;
 	double * px = (double *)x->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		py[i * 2] = px[0];
@@ -246,7 +261,8 @@ static void Tile_string(struct onnx_node_t * n)
 	char ** px = (char **)x->datas;
 	char ** py = (char **)y->datas;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		px = onnx_tensor_broadcast_map_address(x, y, i);
 		if(py[i])

--- a/src/default/TopK.c
+++ b/src/default/TopK.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_TopK(struct onnx_node_t * n)
 {

--- a/src/default/Transpose.c
+++ b/src/default/Transpose.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 struct operator_pdata_t {
 	int * perm;

--- a/src/default/Trilu.c
+++ b/src/default/Trilu.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Trilu(struct onnx_node_t * n)
 {

--- a/src/default/Unique.c
+++ b/src/default/Unique.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Unique(struct onnx_node_t * n)
 {

--- a/src/default/Unsqueeze.c
+++ b/src/default/Unsqueeze.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Unsqueeze_init(struct onnx_node_t * n)
 {
@@ -49,7 +49,8 @@ static void Unsqueeze_operator(struct onnx_node_t * n)
 
 	if(x->type == ONNX_TENSOR_TYPE_STRING)
 	{
-		for(size_t i = 0, l = y->ndata; i < l; i++)
+		size_t i,l;
+		for(i=0, l = y->ndata; i < l; i++)
 		{
 			if(py[i])
 				free(py[i]);

--- a/src/default/Upsample.c
+++ b/src/default/Upsample.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 void resolver_default_op_Upsample(struct onnx_node_t * n)
 {

--- a/src/default/Where.c
+++ b/src/default/Where.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Where_init(struct onnx_node_t * n)
 {
@@ -37,7 +37,8 @@ static void Where_bool(struct onnx_node_t * n)
 	uint8_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -58,7 +59,8 @@ static void Where_int8(struct onnx_node_t * n)
 	int8_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -79,7 +81,8 @@ static void Where_int16(struct onnx_node_t * n)
 	int16_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -100,7 +103,8 @@ static void Where_int32(struct onnx_node_t * n)
 	int32_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -121,7 +125,8 @@ static void Where_int64(struct onnx_node_t * n)
 	int64_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -142,7 +147,8 @@ static void Where_uint8(struct onnx_node_t * n)
 	uint8_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -163,7 +169,8 @@ static void Where_uint16(struct onnx_node_t * n)
 	uint16_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -184,7 +191,8 @@ static void Where_uint32(struct onnx_node_t * n)
 	uint32_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -205,7 +213,8 @@ static void Where_uint64(struct onnx_node_t * n)
 	uint64_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -226,7 +235,8 @@ static void Where_bfloat16(struct onnx_node_t * n)
 	uint16_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -247,7 +257,8 @@ static void Where_float16(struct onnx_node_t * n)
 	uint16_t * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -268,7 +279,8 @@ static void Where_float32(struct onnx_node_t * n)
 	float * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -289,7 +301,8 @@ static void Where_float64(struct onnx_node_t * n)
 	double * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -310,7 +323,8 @@ static void Where_complex64(struct onnx_node_t * n)
 	float * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -332,7 +346,8 @@ static void Where_complex128(struct onnx_node_t * n)
 	double * px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)
@@ -354,7 +369,8 @@ static void Where_string(struct onnx_node_t * n)
 	char ** px;
 	uint8_t * c;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		c = onnx_tensor_broadcast_map_address(x0, y, i);
 		if(*c)

--- a/src/default/Xor.c
+++ b/src/default/Xor.c
@@ -1,4 +1,4 @@
-#include <onnx.h>
+#include "../onnx.h"
 
 static int Xor_init(struct onnx_node_t * n)
 {
@@ -30,7 +30,8 @@ static void Xor_bool(struct onnx_node_t * n)
 	uint8_t * pa;
 	uint8_t * pb;
 
-	for(size_t i = 0, l = y->ndata; i < l; i++)
+	size_t i,l;
+	for(i=0, l = y->ndata; i < l; i++)
 	{
 		pa = onnx_tensor_broadcast_map_address(a, y, i);
 		pb = onnx_tensor_broadcast_map_address(b, y, i);

--- a/src/default/default.c
+++ b/src/default/default.c
@@ -1,4 +1,4 @@
-#include <default/default.h>
+#include "default.h"
 
 void * resolver_default_create(void)
 {

--- a/src/default/default.h
+++ b/src/default/default.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <onnx.h>
+#include "../onnx.h"
 
 void * resolver_default_create(void);
 void resolver_default_destroy(void * rctx);

--- a/src/hmap.c
+++ b/src/hmap.c
@@ -25,7 +25,7 @@
  *
  */
 
-#include <hmap.h>
+#include "hmap.h"
 
 static inline int fls_generic(unsigned int word)
 {

--- a/src/hmap.h
+++ b/src/hmap.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <onnxconf.h>
+#include "onnxconf.h"
 
 struct hmap_entry_t {
 	struct hlist_node node;

--- a/src/onnx.c
+++ b/src/onnx.c
@@ -25,8 +25,8 @@
  *
  */
 
-#include <onnx.h>
-#include <default/default.h>
+#include "onnx.h"
+#include "default/default.h"
 
 #define ONNX_LOG(...)	printf(__VA_ARGS__)
 
@@ -1416,6 +1416,7 @@ struct onnx_tensor_t * onnx_tensor_alloc_from_file(const char * filename)
 void onnx_tensor_free(struct onnx_tensor_t * t)
 {
 	char ** str;
+	size_t idx;
 
 	if(t)
 	{
@@ -1433,7 +1434,7 @@ void onnx_tensor_free(struct onnx_tensor_t * t)
 			if(t->type == ONNX_TENSOR_TYPE_STRING)
 			{
 				str = (char **)t->datas;
-				for(size_t idx = 0; idx < t->ndata; idx++)
+				for(idx = 0; idx < t->ndata; idx++)
 				{
 					if(str[idx])
 						free(str[idx]);
@@ -1562,7 +1563,7 @@ int onnx_tensor_equal(struct onnx_tensor_t * a, struct onnx_tensor_t * b)
 void onnx_tensor_reinit(struct onnx_tensor_t * t, enum onnx_tensor_type_t type, int * dims, int ndim)
 {
 	char ** str;
-	size_t n;
+	size_t n, idx;
 	int sz, i;
 
 	if(t)
@@ -1586,7 +1587,7 @@ void onnx_tensor_reinit(struct onnx_tensor_t * t, enum onnx_tensor_type_t type, 
 			if(t->type == ONNX_TENSOR_TYPE_STRING)
 			{
 				str = (char **)t->datas;
-				for(size_t idx = 0; idx < t->ndata; idx++)
+				for(idx = 0; idx < t->ndata; idx++)
 				{
 					if(str[idx])
 					{
@@ -1664,7 +1665,7 @@ void onnx_tensor_reinit(struct onnx_tensor_t * t, enum onnx_tensor_type_t type, 
 
 void onnx_tensor_apply(struct onnx_tensor_t * t, void * buf, size_t len)
 {
-	size_t l;
+	size_t l, idx;
 	int sz;
 
 	if(t)
@@ -1678,7 +1679,7 @@ void onnx_tensor_apply(struct onnx_tensor_t * t, void * buf, size_t len)
 				{
 					char ** p = (char **)t->datas;
 					char ** q = (char **)buf;
-					for(size_t idx = 0; idx < t->ndata; idx++)
+					for(idx = 0; idx < t->ndata; idx++)
 					{
 						if(p[idx])
 						{
@@ -1687,7 +1688,7 @@ void onnx_tensor_apply(struct onnx_tensor_t * t, void * buf, size_t len)
 						}
 					}
 					l = min(t->ndata, (size_t)len);
-					for(size_t idx = 0; idx < l; idx++)
+					for(idx = 0; idx < l; idx++)
 						p[idx] = strdup(q[idx]);
 				}
 				else
@@ -1744,6 +1745,10 @@ char * onnx_attribute_read_string(struct onnx_node_t * n, const char * name, cha
 	{
 		if(attr->s.len > 0)
 		{
+			attr->s.data=realloc(attr->s.data,attr->s.len+1);
+			if(attr->s.data==NULL)
+				return def;
+				
 			attr->s.data[attr->s.len] = 0;
 			return (char *)attr->s.data;
 		}
@@ -1839,6 +1844,8 @@ void onnx_tensor_dump(struct onnx_tensor_t * t, int detail)
 	void * p;
 	int i, j, k;
 
+	size_t idx;
+
 	if(t)
 	{
 		ONNX_LOG("%s: %s", t->name, onnx_tensor_type_tostring(t->type));
@@ -1873,7 +1880,7 @@ void onnx_tensor_dump(struct onnx_tensor_t * t, int detail)
 					sizes[i] = t->dims[i] * sizes[i + 1];
 					levels[i] = 0;
 				}
-				for(size_t idx = 0; idx < t->ndata; idx++)
+				for(idx = 0; idx < t->ndata; idx++)
 				{
 					for(j = 0; j < t->ndim; j++)
 					{

--- a/src/onnx.h
+++ b/src/onnx.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-#include <onnxconf.h>
-#include <onnx.proto3.pb-c.h>
+#include "onnxconf.h"
+#include "onnx.proto3.pb-c.h"
 
 #define LIBONNX_MAJOY			(1)
 #define LIBONNX_MINIOR			(0)

--- a/src/onnx.proto3.pb-c.c
+++ b/src/onnx.proto3.pb-c.c
@@ -532,6 +532,18 @@ void   onnx__type_proto__map__init
   static const Onnx__TypeProto__Map init_value = ONNX__TYPE_PROTO__MAP__INIT;
   *message = init_value;
 }
+void   onnx__type_proto__optional__init
+                     (Onnx__TypeProto__Optional         *message)
+{
+  static const Onnx__TypeProto__Optional init_value = ONNX__TYPE_PROTO__OPTIONAL__INIT;
+  *message = init_value;
+}
+void   onnx__type_proto__sparse_tensor__init
+                     (Onnx__TypeProto__SparseTensor         *message)
+{
+  static const Onnx__TypeProto__SparseTensor init_value = ONNX__TYPE_PROTO__SPARSE_TENSOR__INIT;
+  *message = init_value;
+}
 void   onnx__type_proto__init
                      (Onnx__TypeProto         *message)
 {
@@ -622,7 +634,52 @@ void   onnx__operator_set_id_proto__free_unpacked
   assert(message->base.descriptor == &onnx__operator_set_id_proto__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCEnumValue onnx__attribute_proto__attribute_type__enum_values_by_number[13] =
+void   onnx__function_proto__init
+                     (Onnx__FunctionProto         *message)
+{
+  static const Onnx__FunctionProto init_value = ONNX__FUNCTION_PROTO__INIT;
+  *message = init_value;
+}
+size_t onnx__function_proto__get_packed_size
+                     (const Onnx__FunctionProto *message)
+{
+  assert(message->base.descriptor == &onnx__function_proto__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t onnx__function_proto__pack
+                     (const Onnx__FunctionProto *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &onnx__function_proto__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t onnx__function_proto__pack_to_buffer
+                     (const Onnx__FunctionProto *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &onnx__function_proto__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Onnx__FunctionProto *
+       onnx__function_proto__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Onnx__FunctionProto *)
+     protobuf_c_message_unpack (&onnx__function_proto__descriptor,
+                                allocator, len, data);
+}
+void   onnx__function_proto__free_unpacked
+                     (Onnx__FunctionProto *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &onnx__function_proto__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+static const ProtobufCEnumValue onnx__attribute_proto__attribute_type__enum_values_by_number[15] =
 {
   { "UNDEFINED", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__UNDEFINED", 0 },
   { "FLOAT", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__FLOAT", 1 },
@@ -637,11 +694,13 @@ static const ProtobufCEnumValue onnx__attribute_proto__attribute_type__enum_valu
   { "GRAPHS", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__GRAPHS", 10 },
   { "SPARSE_TENSOR", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__SPARSE_TENSOR", 11 },
   { "SPARSE_TENSORS", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__SPARSE_TENSORS", 12 },
+  { "TYPE_PROTO", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__TYPE_PROTO", 13 },
+  { "TYPE_PROTOS", "ONNX__ATTRIBUTE_PROTO__ATTRIBUTE_TYPE__TYPE_PROTOS", 14 },
 };
 static const ProtobufCIntRange onnx__attribute_proto__attribute_type__value_ranges[] = {
-{0, 0},{0, 13}
+{0, 0},{0, 15}
 };
-static const ProtobufCEnumValueIndex onnx__attribute_proto__attribute_type__enum_values_by_name[13] =
+static const ProtobufCEnumValueIndex onnx__attribute_proto__attribute_type__enum_values_by_name[15] =
 {
   { "FLOAT", 1 },
   { "FLOATS", 6 },
@@ -655,6 +714,8 @@ static const ProtobufCEnumValueIndex onnx__attribute_proto__attribute_type__enum
   { "STRINGS", 8 },
   { "TENSOR", 4 },
   { "TENSORS", 9 },
+  { "TYPE_PROTO", 13 },
+  { "TYPE_PROTOS", 14 },
   { "UNDEFINED", 0 },
 };
 const ProtobufCEnumDescriptor onnx__attribute_proto__attribute_type__descriptor =
@@ -664,15 +725,15 @@ const ProtobufCEnumDescriptor onnx__attribute_proto__attribute_type__descriptor 
   "AttributeType",
   "Onnx__AttributeProto__AttributeType",
   "onnx",
-  13,
+  15,
   onnx__attribute_proto__attribute_type__enum_values_by_number,
-  13,
+  15,
   onnx__attribute_proto__attribute_type__enum_values_by_name,
   1,
   onnx__attribute_proto__attribute_type__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor onnx__attribute_proto__field_descriptors[16] =
+static const ProtobufCFieldDescriptor onnx__attribute_proto__field_descriptors[18] =
 {
   {
     "name",
@@ -819,6 +880,30 @@ static const ProtobufCFieldDescriptor onnx__attribute_proto__field_descriptors[1
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
+    "tp",
+    14,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__AttributeProto, tp),
+    &onnx__type_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "type_protos",
+    15,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__AttributeProto, n_type_protos),
+    offsetof(Onnx__AttributeProto, type_protos),
+    &onnx__type_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
     "type",
     20,
     PROTOBUF_C_LABEL_NONE,
@@ -876,21 +961,23 @@ static const unsigned onnx__attribute_proto__field_indices_by_name[] = {
   2,   /* field[2] = i */
   7,   /* field[7] = ints */
   0,   /* field[0] = name */
-  13,   /* field[13] = ref_attr_name */
+  15,   /* field[15] = ref_attr_name */
   3,   /* field[3] = s */
-  14,   /* field[14] = sparse_tensor */
-  15,   /* field[15] = sparse_tensors */
+  16,   /* field[16] = sparse_tensor */
+  17,   /* field[17] = sparse_tensors */
   8,   /* field[8] = strings */
   4,   /* field[4] = t */
   9,   /* field[9] = tensors */
-  12,   /* field[12] = type */
+  12,   /* field[12] = tp */
+  14,   /* field[14] = type */
+  13,   /* field[13] = type_protos */
 };
 static const ProtobufCIntRange onnx__attribute_proto__number_ranges[3 + 1] =
 {
   { 1, 0 },
   { 13, 11 },
-  { 20, 12 },
-  { 0, 16 }
+  { 20, 14 },
+  { 0, 18 }
 };
 const ProtobufCMessageDescriptor onnx__attribute_proto__descriptor =
 {
@@ -900,7 +987,7 @@ const ProtobufCMessageDescriptor onnx__attribute_proto__descriptor =
   "Onnx__AttributeProto",
   "onnx",
   sizeof(Onnx__AttributeProto),
-  16,
+  18,
   onnx__attribute_proto__field_descriptors,
   onnx__attribute_proto__field_indices_by_name,
   3,  onnx__attribute_proto__number_ranges,
@@ -1164,7 +1251,7 @@ const ProtobufCMessageDescriptor onnx__training_info_proto__descriptor =
   (ProtobufCMessageInit) onnx__training_info_proto__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor onnx__model_proto__field_descriptors[10] =
+static const ProtobufCFieldDescriptor onnx__model_proto__field_descriptors[11] =
 {
   {
     "ir_version",
@@ -1286,10 +1373,23 @@ static const ProtobufCFieldDescriptor onnx__model_proto__field_descriptors[10] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "functions",
+    25,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__ModelProto, n_functions),
+    offsetof(Onnx__ModelProto, functions),
+    &onnx__function_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned onnx__model_proto__field_indices_by_name[] = {
   5,   /* field[5] = doc_string */
   3,   /* field[3] = domain */
+  10,   /* field[10] = functions */
   6,   /* field[6] = graph */
   0,   /* field[0] = ir_version */
   8,   /* field[8] = metadata_props */
@@ -1299,12 +1399,13 @@ static const unsigned onnx__model_proto__field_indices_by_name[] = {
   2,   /* field[2] = producer_version */
   9,   /* field[9] = training_info */
 };
-static const ProtobufCIntRange onnx__model_proto__number_ranges[3 + 1] =
+static const ProtobufCIntRange onnx__model_proto__number_ranges[4 + 1] =
 {
   { 1, 0 },
   { 14, 8 },
   { 20, 9 },
-  { 0, 10 }
+  { 25, 10 },
+  { 0, 11 }
 };
 const ProtobufCMessageDescriptor onnx__model_proto__descriptor =
 {
@@ -1314,10 +1415,10 @@ const ProtobufCMessageDescriptor onnx__model_proto__descriptor =
   "Onnx__ModelProto",
   "onnx",
   sizeof(Onnx__ModelProto),
-  10,
+  11,
   onnx__model_proto__field_descriptors,
   onnx__model_proto__field_indices_by_name,
-  3,  onnx__model_proto__number_ranges,
+  4,  onnx__model_proto__number_ranges,
   (ProtobufCMessageInit) onnx__model_proto__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
@@ -2217,7 +2318,96 @@ const ProtobufCMessageDescriptor onnx__type_proto__map__descriptor =
   (ProtobufCMessageInit) onnx__type_proto__map__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor onnx__type_proto__field_descriptors[4] =
+static const ProtobufCFieldDescriptor onnx__type_proto__optional__field_descriptors[1] =
+{
+  {
+    "elem_type",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__TypeProto__Optional, elem_type),
+    &onnx__type_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned onnx__type_proto__optional__field_indices_by_name[] = {
+  0,   /* field[0] = elem_type */
+};
+static const ProtobufCIntRange onnx__type_proto__optional__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor onnx__type_proto__optional__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "onnx.TypeProto.Optional",
+  "Optional",
+  "Onnx__TypeProto__Optional",
+  "onnx",
+  sizeof(Onnx__TypeProto__Optional),
+  1,
+  onnx__type_proto__optional__field_descriptors,
+  onnx__type_proto__optional__field_indices_by_name,
+  1,  onnx__type_proto__optional__number_ranges,
+  (ProtobufCMessageInit) onnx__type_proto__optional__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor onnx__type_proto__sparse_tensor__field_descriptors[2] =
+{
+  {
+    "elem_type",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT32,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__TypeProto__SparseTensor, elem_type),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "shape",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__TypeProto__SparseTensor, shape),
+    &onnx__tensor_shape_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned onnx__type_proto__sparse_tensor__field_indices_by_name[] = {
+  0,   /* field[0] = elem_type */
+  1,   /* field[1] = shape */
+};
+static const ProtobufCIntRange onnx__type_proto__sparse_tensor__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor onnx__type_proto__sparse_tensor__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "onnx.TypeProto.SparseTensor",
+  "SparseTensor",
+  "Onnx__TypeProto__SparseTensor",
+  "onnx",
+  sizeof(Onnx__TypeProto__SparseTensor),
+  2,
+  onnx__type_proto__sparse_tensor__field_descriptors,
+  onnx__type_proto__sparse_tensor__field_indices_by_name,
+  1,  onnx__type_proto__sparse_tensor__number_ranges,
+  (ProtobufCMessageInit) onnx__type_proto__sparse_tensor__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor onnx__type_proto__field_descriptors[6] =
 {
   {
     "tensor_type",
@@ -2267,18 +2457,45 @@ static const ProtobufCFieldDescriptor onnx__type_proto__field_descriptors[4] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "sparse_tensor_type",
+    8,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__TypeProto, value_case),
+    offsetof(Onnx__TypeProto, sparse_tensor_type),
+    &onnx__type_proto__sparse_tensor__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "optional_type",
+    9,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__TypeProto, value_case),
+    offsetof(Onnx__TypeProto, optional_type),
+    &onnx__type_proto__optional__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned onnx__type_proto__field_indices_by_name[] = {
   3,   /* field[3] = denotation */
   2,   /* field[2] = map_type */
+  5,   /* field[5] = optional_type */
   1,   /* field[1] = sequence_type */
+  4,   /* field[4] = sparse_tensor_type */
   0,   /* field[0] = tensor_type */
 };
-static const ProtobufCIntRange onnx__type_proto__number_ranges[2 + 1] =
+static const ProtobufCIntRange onnx__type_proto__number_ranges[3 + 1] =
 {
   { 1, 0 },
   { 4, 1 },
-  { 0, 4 }
+  { 8, 4 },
+  { 0, 6 }
 };
 const ProtobufCMessageDescriptor onnx__type_proto__descriptor =
 {
@@ -2288,10 +2505,10 @@ const ProtobufCMessageDescriptor onnx__type_proto__descriptor =
   "Onnx__TypeProto",
   "onnx",
   sizeof(Onnx__TypeProto),
-  4,
+  6,
   onnx__type_proto__field_descriptors,
   onnx__type_proto__field_indices_by_name,
-  2,  onnx__type_proto__number_ranges,
+  3,  onnx__type_proto__number_ranges,
   (ProtobufCMessageInit) onnx__type_proto__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
@@ -2346,7 +2563,137 @@ const ProtobufCMessageDescriptor onnx__operator_set_id_proto__descriptor =
   (ProtobufCMessageInit) onnx__operator_set_id_proto__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue onnx__version__enum_values_by_number[8] =
+static const ProtobufCFieldDescriptor onnx__function_proto__field_descriptors[8] =
+{
+  {
+    "name",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__FunctionProto, name),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "input",
+    4,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_STRING,
+    offsetof(Onnx__FunctionProto, n_input),
+    offsetof(Onnx__FunctionProto, input),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "output",
+    5,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_STRING,
+    offsetof(Onnx__FunctionProto, n_output),
+    offsetof(Onnx__FunctionProto, output),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "attribute",
+    6,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_STRING,
+    offsetof(Onnx__FunctionProto, n_attribute),
+    offsetof(Onnx__FunctionProto, attribute),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "node",
+    7,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__FunctionProto, n_node),
+    offsetof(Onnx__FunctionProto, node),
+    &onnx__node_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "doc_string",
+    8,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__FunctionProto, doc_string),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "opset_import",
+    9,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Onnx__FunctionProto, n_opset_import),
+    offsetof(Onnx__FunctionProto, opset_import),
+    &onnx__operator_set_id_proto__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "domain",
+    10,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Onnx__FunctionProto, domain),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned onnx__function_proto__field_indices_by_name[] = {
+  3,   /* field[3] = attribute */
+  5,   /* field[5] = doc_string */
+  7,   /* field[7] = domain */
+  1,   /* field[1] = input */
+  0,   /* field[0] = name */
+  4,   /* field[4] = node */
+  6,   /* field[6] = opset_import */
+  2,   /* field[2] = output */
+};
+static const ProtobufCIntRange onnx__function_proto__number_ranges[2 + 1] =
+{
+  { 1, 0 },
+  { 4, 1 },
+  { 0, 8 }
+};
+const ProtobufCMessageDescriptor onnx__function_proto__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "onnx.FunctionProto",
+  "FunctionProto",
+  "Onnx__FunctionProto",
+  "onnx",
+  sizeof(Onnx__FunctionProto),
+  8,
+  onnx__function_proto__field_descriptors,
+  onnx__function_proto__field_indices_by_name,
+  2,  onnx__function_proto__number_ranges,
+  (ProtobufCMessageInit) onnx__function_proto__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCEnumValue onnx__version__enum_values_by_number[9] =
 {
   { "_START_VERSION", "ONNX__VERSION___START_VERSION", 0 },
   { "IR_VERSION_2017_10_10", "ONNX__VERSION__IR_VERSION_2017_10_10", 1 },
@@ -2355,20 +2702,22 @@ static const ProtobufCEnumValue onnx__version__enum_values_by_number[8] =
   { "IR_VERSION_2019_1_22", "ONNX__VERSION__IR_VERSION_2019_1_22", 4 },
   { "IR_VERSION_2019_3_18", "ONNX__VERSION__IR_VERSION_2019_3_18", 5 },
   { "IR_VERSION_2019_9_19", "ONNX__VERSION__IR_VERSION_2019_9_19", 6 },
-  { "IR_VERSION", "ONNX__VERSION__IR_VERSION", 7 },
+  { "IR_VERSION_2020_5_8", "ONNX__VERSION__IR_VERSION_2020_5_8", 7 },
+  { "IR_VERSION", "ONNX__VERSION__IR_VERSION", 8 },
 };
 static const ProtobufCIntRange onnx__version__value_ranges[] = {
-{0, 0},{0, 8}
+{0, 0},{0, 9}
 };
-static const ProtobufCEnumValueIndex onnx__version__enum_values_by_name[8] =
+static const ProtobufCEnumValueIndex onnx__version__enum_values_by_name[9] =
 {
-  { "IR_VERSION", 7 },
+  { "IR_VERSION", 8 },
   { "IR_VERSION_2017_10_10", 1 },
   { "IR_VERSION_2017_10_30", 2 },
   { "IR_VERSION_2017_11_3", 3 },
   { "IR_VERSION_2019_1_22", 4 },
   { "IR_VERSION_2019_3_18", 5 },
   { "IR_VERSION_2019_9_19", 6 },
+  { "IR_VERSION_2020_5_8", 7 },
   { "_START_VERSION", 0 },
 };
 const ProtobufCEnumDescriptor onnx__version__descriptor =
@@ -2378,11 +2727,39 @@ const ProtobufCEnumDescriptor onnx__version__descriptor =
   "Version",
   "Onnx__Version",
   "onnx",
-  8,
+  9,
   onnx__version__enum_values_by_number,
-  8,
+  9,
   onnx__version__enum_values_by_name,
   1,
   onnx__version__value_ranges,
+  NULL,NULL,NULL,NULL   /* reserved[1234] */
+};
+static const ProtobufCEnumValue onnx__operator_status__enum_values_by_number[2] =
+{
+  { "EXPERIMENTAL", "ONNX__OPERATOR_STATUS__EXPERIMENTAL", 0 },
+  { "STABLE", "ONNX__OPERATOR_STATUS__STABLE", 1 },
+};
+static const ProtobufCIntRange onnx__operator_status__value_ranges[] = {
+{0, 0},{0, 2}
+};
+static const ProtobufCEnumValueIndex onnx__operator_status__enum_values_by_name[2] =
+{
+  { "EXPERIMENTAL", 0 },
+  { "STABLE", 1 },
+};
+const ProtobufCEnumDescriptor onnx__operator_status__descriptor =
+{
+  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
+  "onnx.OperatorStatus",
+  "OperatorStatus",
+  "Onnx__OperatorStatus",
+  "onnx",
+  2,
+  onnx__operator_status__enum_values_by_number,
+  2,
+  onnx__operator_status__enum_values_by_name,
+  1,
+  onnx__operator_status__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };

--- a/src/onnxconf.h
+++ b/src/onnxconf.h
@@ -10,11 +10,11 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-#include <malloc.h>
+ 
 #include <float.h>
 #include <math.h>
-#include <list.h>
-#include <hmap.h>
+#include "list.h"
+#include "hmap.h"
 
 /*
  * Macro
@@ -26,7 +26,9 @@ extern "C" {
 /*
  * little or big endian
  */
-#define ONNX_LITTLE_ENDIAN	(1)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	#define ONNX_LITTLE_ENDIAN	(1)
+#endif
 
 static inline uint16_t __swab16(uint16_t x)
 {

--- a/src/protobuf-c.h
+++ b/src/protobuf-c.h
@@ -200,6 +200,7 @@ size_t foo__bar__baz_bah__pack_to_buffer
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
+#include "onnxconf.h"
 
 #ifdef __cplusplus
 # define PROTOBUF_C__BEGIN_DECLS	extern "C" {


### PR DESCRIPTION
* ONNX protobuf updated, 
* Tiny Yolo V2 string allocation valgrind output solved,
* Libonnx source calling converted from <onnx.h> type to "onnx.h" type, because it seeks for /usr/local in some cases
* C99 compatibility increased
* Little endian, big endian compatibility increased
and some minor fixes