### PR TITLE
Rename cxx conflicts 

### DIFF
--- a/examples/benchmark/main.c
+++ b/examples/benchmark/main.c
@@ -115,7 +115,7 @@ static void onnx_run_benchmark(struct onnx_context_t * ctx, int count)
 		{
 			n = &ctx->g->nodes[i];
 			if(n->reshape(n))
-				n->operator(n);
+				n->op(n);
 		}
 		while(count-- > 0)
 		{
@@ -128,7 +128,7 @@ static void onnx_run_benchmark(struct onnx_context_t * ctx, int count)
 				p = profiler_search(m, name);
 				profiler_begin(p);
 				if(n->reshape(n))
-					n->operator(n);
+					n->op(n);
 				profiler_end(p);
 			}
 		}

--- a/src/default/Abs.c
+++ b/src/default/Abs.c
@@ -170,73 +170,73 @@ void resolver_default_op_Abs(struct onnx_node_t * n)
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int8;
+			n->op = Abs_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int16;
+			n->op = Abs_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int32;
+			n->op = Abs_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int64;
+			n->op = Abs_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint8;
+			n->op = Abs_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint16;
+			n->op = Abs_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint32;
+			n->op = Abs_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint64;
+			n->op = Abs_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_bfloat16;
+			n->op = Abs_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float16;
+			n->op = Abs_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float32;
+			n->op = Abs_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float64;
+			n->op = Abs_float64;
 			break;
 		default:
 			break;
@@ -250,67 +250,67 @@ void resolver_default_op_Abs(struct onnx_node_t * n)
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int8;
+			n->op = Abs_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int16;
+			n->op = Abs_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int32;
+			n->op = Abs_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_int64;
+			n->op = Abs_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint8;
+			n->op = Abs_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint16;
+			n->op = Abs_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint32;
+			n->op = Abs_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_uint64;
+			n->op = Abs_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float16;
+			n->op = Abs_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float32;
+			n->op = Abs_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float64;
+			n->op = Abs_float64;
 			break;
 		default:
 			break;
@@ -324,19 +324,19 @@ void resolver_default_op_Abs(struct onnx_node_t * n)
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float16;
+			n->op = Abs_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float32;
+			n->op = Abs_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Abs_init;
 			n->exit = Abs_exit;
 			n->reshape = Abs_reshape;
-			n->operator = Abs_float64;
+			n->op = Abs_float64;
 			break;
 		default:
 			break;

--- a/src/default/Acos.c
+++ b/src/default/Acos.c
@@ -82,25 +82,25 @@ void resolver_default_op_Acos(struct onnx_node_t * n)
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_bfloat16;
+			n->op = Acos_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float16;
+			n->op = Acos_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float32;
+			n->op = Acos_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float64;
+			n->op = Acos_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Acos(struct onnx_node_t * n)
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float16;
+			n->op = Acos_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float32;
+			n->op = Acos_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Acos_init;
 			n->exit = Acos_exit;
 			n->reshape = Acos_reshape;
-			n->operator = Acos_float64;
+			n->op = Acos_float64;
 			break;
 		default:
 			break;

--- a/src/default/Acosh.c
+++ b/src/default/Acosh.c
@@ -86,25 +86,25 @@ void resolver_default_op_Acosh(struct onnx_node_t * n)
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_bfloat16;
+			n->op = Acosh_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float16;
+			n->op = Acosh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float32;
+			n->op = Acosh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float64;
+			n->op = Acosh_float64;
 			break;
 		default:
 			break;
@@ -118,19 +118,19 @@ void resolver_default_op_Acosh(struct onnx_node_t * n)
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float16;
+			n->op = Acosh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float32;
+			n->op = Acosh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Acosh_init;
 			n->exit = Acosh_exit;
 			n->reshape = Acosh_reshape;
-			n->operator = Acosh_float64;
+			n->op = Acosh_float64;
 			break;
 		default:
 			break;

--- a/src/default/Add.c
+++ b/src/default/Add.c
@@ -235,73 +235,73 @@ void resolver_default_op_Add(struct onnx_node_t * n)
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int8;
+			n->op = Add_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int16;
+			n->op = Add_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int32;
+			n->op = Add_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int64;
+			n->op = Add_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint8;
+			n->op = Add_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint16;
+			n->op = Add_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint32;
+			n->op = Add_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint64;
+			n->op = Add_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_13_bfloat16;
+			n->op = Add_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float16;
+			n->op = Add_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float32;
+			n->op = Add_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float64;
+			n->op = Add_float64;
 			break;
 		default:
 			break;
@@ -315,49 +315,49 @@ void resolver_default_op_Add(struct onnx_node_t * n)
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int32;
+			n->op = Add_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int64;
+			n->op = Add_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint32;
+			n->op = Add_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint64;
+			n->op = Add_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_13_bfloat16;
+			n->op = Add_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float16;
+			n->op = Add_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float32;
+			n->op = Add_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float64;
+			n->op = Add_float64;
 			break;
 		default:
 			break;
@@ -371,43 +371,43 @@ void resolver_default_op_Add(struct onnx_node_t * n)
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int32;
+			n->op = Add_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_int64;
+			n->op = Add_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint32;
+			n->op = Add_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_uint64;
+			n->op = Add_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float16;
+			n->op = Add_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float32;
+			n->op = Add_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Add_init;
 			n->exit = Add_exit;
 			n->reshape = Add_reshape;
-			n->operator = Add_float64;
+			n->op = Add_float64;
 			break;
 		default:
 			break;

--- a/src/default/And.c
+++ b/src/default/And.c
@@ -48,7 +48,7 @@ void resolver_default_op_And(struct onnx_node_t * n)
 			n->init = And_7_init;
 			n->exit = And_7_exit;
 			n->reshape = And_7_reshape;
-			n->operator = And_7_bool;
+			n->op = And_7_bool;
 			break;
 		default:
 			break;

--- a/src/default/ArgMax.c
+++ b/src/default/ArgMax.c
@@ -669,73 +669,73 @@ void resolver_default_op_ArgMax(struct onnx_node_t * n)
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int8;
+			n->op = ArgMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int16;
+			n->op = ArgMax_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int32;
+			n->op = ArgMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int64;
+			n->op = ArgMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint8;
+			n->op = ArgMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint16;
+			n->op = ArgMax_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint32;
+			n->op = ArgMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint64;
+			n->op = ArgMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_bfloat16;
+			n->op = ArgMax_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float16;
+			n->op = ArgMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float32;
+			n->op = ArgMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float64;
+			n->op = ArgMax_float64;
 			break;
 		default:
 			break;
@@ -749,67 +749,67 @@ void resolver_default_op_ArgMax(struct onnx_node_t * n)
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int8;
+			n->op = ArgMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int16;
+			n->op = ArgMax_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int32;
+			n->op = ArgMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int64;
+			n->op = ArgMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint8;
+			n->op = ArgMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint16;
+			n->op = ArgMax_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint32;
+			n->op = ArgMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint64;
+			n->op = ArgMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float16;
+			n->op = ArgMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float32;
+			n->op = ArgMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float64;
+			n->op = ArgMax_float64;
 			break;
 		default:
 			break;
@@ -823,67 +823,67 @@ void resolver_default_op_ArgMax(struct onnx_node_t * n)
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int8;
+			n->op = ArgMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int16;
+			n->op = ArgMax_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int32;
+			n->op = ArgMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int64;
+			n->op = ArgMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint8;
+			n->op = ArgMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint16;
+			n->op = ArgMax_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint32;
+			n->op = ArgMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint64;
+			n->op = ArgMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float16;
+			n->op = ArgMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float32;
+			n->op = ArgMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float64;
+			n->op = ArgMax_float64;
 			break;
 		default:
 			break;
@@ -897,67 +897,67 @@ void resolver_default_op_ArgMax(struct onnx_node_t * n)
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int8;
+			n->op = ArgMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int16;
+			n->op = ArgMax_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int32;
+			n->op = ArgMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_int64;
+			n->op = ArgMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint8;
+			n->op = ArgMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint16;
+			n->op = ArgMax_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint32;
+			n->op = ArgMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_uint64;
+			n->op = ArgMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float16;
+			n->op = ArgMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float32;
+			n->op = ArgMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMax_init;
 			n->exit = ArgMax_exit;
 			n->reshape = ArgMax_reshape;
-			n->operator = ArgMax_float64;
+			n->op = ArgMax_float64;
 			break;
 		default:
 			break;

--- a/src/default/ArgMin.c
+++ b/src/default/ArgMin.c
@@ -669,73 +669,73 @@ void resolver_default_op_ArgMin(struct onnx_node_t * n)
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int8;
+			n->op = ArgMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int16;
+			n->op = ArgMin_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int32;
+			n->op = ArgMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int64;
+			n->op = ArgMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint8;
+			n->op = ArgMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint16;
+			n->op = ArgMin_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint32;
+			n->op = ArgMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint64;
+			n->op = ArgMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_bfloat16;
+			n->op = ArgMin_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float16;
+			n->op = ArgMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float32;
+			n->op = ArgMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float64;
+			n->op = ArgMin_float64;
 			break;
 		default:
 			break;
@@ -749,67 +749,67 @@ void resolver_default_op_ArgMin(struct onnx_node_t * n)
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int8;
+			n->op = ArgMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int16;
+			n->op = ArgMin_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int32;
+			n->op = ArgMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int64;
+			n->op = ArgMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint8;
+			n->op = ArgMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint16;
+			n->op = ArgMin_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint32;
+			n->op = ArgMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint64;
+			n->op = ArgMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float16;
+			n->op = ArgMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float32;
+			n->op = ArgMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float64;
+			n->op = ArgMin_float64;
 			break;
 		default:
 			break;
@@ -823,67 +823,67 @@ void resolver_default_op_ArgMin(struct onnx_node_t * n)
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int8;
+			n->op = ArgMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int16;
+			n->op = ArgMin_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int32;
+			n->op = ArgMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int64;
+			n->op = ArgMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint8;
+			n->op = ArgMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint16;
+			n->op = ArgMin_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint32;
+			n->op = ArgMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint64;
+			n->op = ArgMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float16;
+			n->op = ArgMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float32;
+			n->op = ArgMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float64;
+			n->op = ArgMin_float64;
 			break;
 		default:
 			break;
@@ -897,67 +897,67 @@ void resolver_default_op_ArgMin(struct onnx_node_t * n)
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int8;
+			n->op = ArgMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int16;
+			n->op = ArgMin_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int32;
+			n->op = ArgMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_int64;
+			n->op = ArgMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint8;
+			n->op = ArgMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint16;
+			n->op = ArgMin_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint32;
+			n->op = ArgMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_uint64;
+			n->op = ArgMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float16;
+			n->op = ArgMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float32;
+			n->op = ArgMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ArgMin_init;
 			n->exit = ArgMin_exit;
 			n->reshape = ArgMin_reshape;
-			n->operator = ArgMin_float64;
+			n->op = ArgMin_float64;
 			break;
 		default:
 			break;

--- a/src/default/Asin.c
+++ b/src/default/Asin.c
@@ -82,25 +82,25 @@ void resolver_default_op_Asin(struct onnx_node_t * n)
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_bfloat16;
+			n->op = Asin_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float16;
+			n->op = Asin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float32;
+			n->op = Asin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float64;
+			n->op = Asin_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Asin(struct onnx_node_t * n)
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float16;
+			n->op = Asin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float32;
+			n->op = Asin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Asin_init;
 			n->exit = Asin_exit;
 			n->reshape = Asin_reshape;
-			n->operator = Asin_float64;
+			n->op = Asin_float64;
 			break;
 		default:
 			break;

--- a/src/default/Asinh.c
+++ b/src/default/Asinh.c
@@ -82,25 +82,25 @@ void resolver_default_op_Asinh(struct onnx_node_t * n)
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_bfloat16;
+			n->op = Asinh_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float16;
+			n->op = Asinh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float32;
+			n->op = Asinh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float64;
+			n->op = Asinh_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Asinh(struct onnx_node_t * n)
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float16;
+			n->op = Asinh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float32;
+			n->op = Asinh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Asinh_init;
 			n->exit = Asinh_exit;
 			n->reshape = Asinh_reshape;
-			n->operator = Asinh_float64;
+			n->op = Asinh_float64;
 			break;
 		default:
 			break;

--- a/src/default/Atan.c
+++ b/src/default/Atan.c
@@ -82,25 +82,25 @@ void resolver_default_op_Atan(struct onnx_node_t * n)
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_bfloat16;
+			n->op = Atan_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float16;
+			n->op = Atan_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float32;
+			n->op = Atan_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float64;
+			n->op = Atan_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Atan(struct onnx_node_t * n)
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float16;
+			n->op = Atan_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float32;
+			n->op = Atan_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Atan_init;
 			n->exit = Atan_exit;
 			n->reshape = Atan_reshape;
-			n->operator = Atan_float64;
+			n->op = Atan_float64;
 			break;
 		default:
 			break;

--- a/src/default/Atanh.c
+++ b/src/default/Atanh.c
@@ -82,25 +82,25 @@ void resolver_default_op_Atanh(struct onnx_node_t * n)
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_bfloat16;
+			n->op = Atanh_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float16;
+			n->op = Atanh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float32;
+			n->op = Atanh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float64;
+			n->op = Atanh_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Atanh(struct onnx_node_t * n)
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float16;
+			n->op = Atanh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float32;
+			n->op = Atanh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Atanh_init;
 			n->exit = Atanh_exit;
 			n->reshape = Atanh_reshape;
-			n->operator = Atanh_float64;
+			n->op = Atanh_float64;
 			break;
 		default:
 			break;

--- a/src/default/AveragePool.c
+++ b/src/default/AveragePool.c
@@ -362,19 +362,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;
@@ -388,19 +388,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;
@@ -414,19 +414,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;
@@ -440,19 +440,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;
@@ -466,19 +466,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;
@@ -492,19 +492,19 @@ void resolver_default_op_AveragePool(struct onnx_node_t * n)
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float16;
+			n->op = AveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float32;
+			n->op = AveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = AveragePool_init;
 			n->exit = AveragePool_exit;
 			n->reshape = AveragePool_reshape;
-			n->operator = AveragePool_float64;
+			n->op = AveragePool_float64;
 			break;
 		default:
 			break;

--- a/src/default/BatchNormalization.c
+++ b/src/default/BatchNormalization.c
@@ -152,19 +152,19 @@ void resolver_default_op_BatchNormalization(struct onnx_node_t * n)
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float16;
+			n->op = BatchNormalization_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float32;
+			n->op = BatchNormalization_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float64;
+			n->op = BatchNormalization_float64;
 			break;
 		default:
 			break;
@@ -178,19 +178,19 @@ void resolver_default_op_BatchNormalization(struct onnx_node_t * n)
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float16;
+			n->op = BatchNormalization_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float32;
+			n->op = BatchNormalization_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = BatchNormalization_init;
 			n->exit = BatchNormalization_exit;
 			n->reshape = BatchNormalization_reshape;
-			n->operator = BatchNormalization_float64;
+			n->op = BatchNormalization_float64;
 			break;
 		default:
 			break;

--- a/src/default/BitShift.c
+++ b/src/default/BitShift.c
@@ -169,25 +169,25 @@ void resolver_default_op_BitShift(struct onnx_node_t * n)
 			n->init = BitShift_init;
 			n->exit = BitShift_exit;
 			n->reshape = BitShift_reshape;
-			n->operator = BitShift_uint8;
+			n->op = BitShift_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = BitShift_init;
 			n->exit = BitShift_exit;
 			n->reshape = BitShift_reshape;
-			n->operator = BitShift_uint16;
+			n->op = BitShift_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = BitShift_init;
 			n->exit = BitShift_exit;
 			n->reshape = BitShift_reshape;
-			n->operator = BitShift_uint32;
+			n->op = BitShift_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = BitShift_init;
 			n->exit = BitShift_exit;
 			n->reshape = BitShift_reshape;
-			n->operator = BitShift_uint64;
+			n->op = BitShift_uint64;
 			break;
 		default:
 			break;

--- a/src/default/BitwiseAnd.c
+++ b/src/default/BitwiseAnd.c
@@ -167,49 +167,49 @@ void resolver_default_op_BitwiseAnd(struct onnx_node_t * n)
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_int8;
+			n->op = BitwiseAnd_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_int16;
+			n->op = BitwiseAnd_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_int32;
+			n->op = BitwiseAnd_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_int64;
+			n->op = BitwiseAnd_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_uint8;
+			n->op = BitwiseAnd_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_uint16;
+			n->op = BitwiseAnd_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_uint32;
+			n->op = BitwiseAnd_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = BitwiseAnd_init;
 			n->exit = BitwiseAnd_exit;
 			n->reshape = BitwiseAnd_reshape;
-			n->operator = BitwiseAnd_uint64;
+			n->op = BitwiseAnd_uint64;
 			break;
 		default:
 			break;

--- a/src/default/BitwiseNot.c
+++ b/src/default/BitwiseNot.c
@@ -118,49 +118,49 @@ void resolver_default_op_BitwiseNot(struct onnx_node_t * n)
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_int8;
+			n->op = BitwiseNot_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_int16;
+			n->op = BitwiseNot_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_int32;
+			n->op = BitwiseNot_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_int64;
+			n->op = BitwiseNot_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_uint8;
+			n->op = BitwiseNot_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_uint16;
+			n->op = BitwiseNot_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_uint32;
+			n->op = BitwiseNot_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = BitwiseNot_init;
 			n->exit = BitwiseNot_exit;
 			n->reshape = BitwiseNot_reshape;
-			n->operator = BitwiseNot_uint64;
+			n->op = BitwiseNot_uint64;
 			break;
 		default:
 			break;

--- a/src/default/BitwiseOr.c
+++ b/src/default/BitwiseOr.c
@@ -167,49 +167,49 @@ void resolver_default_op_BitwiseOr(struct onnx_node_t * n)
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_int8;
+			n->op = BitwiseOr_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_int16;
+			n->op = BitwiseOr_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_int32;
+			n->op = BitwiseOr_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_int64;
+			n->op = BitwiseOr_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_uint8;
+			n->op = BitwiseOr_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_uint16;
+			n->op = BitwiseOr_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_uint32;
+			n->op = BitwiseOr_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = BitwiseOr_init;
 			n->exit = BitwiseOr_exit;
 			n->reshape = BitwiseOr_reshape;
-			n->operator = BitwiseOr_uint64;
+			n->op = BitwiseOr_uint64;
 			break;
 		default:
 			break;

--- a/src/default/BitwiseXor.c
+++ b/src/default/BitwiseXor.c
@@ -167,49 +167,49 @@ void resolver_default_op_BitwiseXor(struct onnx_node_t * n)
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_int8;
+			n->op = BitwiseXor_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_int16;
+			n->op = BitwiseXor_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_int32;
+			n->op = BitwiseXor_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_int64;
+			n->op = BitwiseXor_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_uint8;
+			n->op = BitwiseXor_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_uint16;
+			n->op = BitwiseXor_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_uint32;
+			n->op = BitwiseXor_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = BitwiseXor_init;
 			n->exit = BitwiseXor_exit;
 			n->reshape = BitwiseXor_reshape;
-			n->operator = BitwiseXor_uint64;
+			n->op = BitwiseXor_uint64;
 			break;
 		default:
 			break;

--- a/src/default/Cast.c
+++ b/src/default/Cast.c
@@ -1713,85 +1713,85 @@ void resolver_default_op_Cast(struct onnx_node_t * n)
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_bool;
+			n->op = Cast_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int8;
+			n->op = Cast_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int16;
+			n->op = Cast_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int32;
+			n->op = Cast_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int64;
+			n->op = Cast_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint8;
+			n->op = Cast_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint16;
+			n->op = Cast_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint32;
+			n->op = Cast_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint64;
+			n->op = Cast_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_bfloat16;
+			n->op = Cast_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float16;
+			n->op = Cast_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float32;
+			n->op = Cast_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float64;
+			n->op = Cast_float64;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_string;
+			n->op = Cast_string;
 			break;
 		default:
 			break;
@@ -1805,79 +1805,79 @@ void resolver_default_op_Cast(struct onnx_node_t * n)
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_bool;
+			n->op = Cast_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int8;
+			n->op = Cast_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int16;
+			n->op = Cast_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int32;
+			n->op = Cast_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int64;
+			n->op = Cast_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint8;
+			n->op = Cast_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint16;
+			n->op = Cast_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint32;
+			n->op = Cast_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint64;
+			n->op = Cast_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float16;
+			n->op = Cast_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float32;
+			n->op = Cast_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float64;
+			n->op = Cast_float64;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_string;
+			n->op = Cast_string;
 			break;
 		default:
 			break;
@@ -1891,73 +1891,73 @@ void resolver_default_op_Cast(struct onnx_node_t * n)
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_bool;
+			n->op = Cast_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int8;
+			n->op = Cast_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int16;
+			n->op = Cast_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int32;
+			n->op = Cast_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_int64;
+			n->op = Cast_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint8;
+			n->op = Cast_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint16;
+			n->op = Cast_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint32;
+			n->op = Cast_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_uint64;
+			n->op = Cast_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float16;
+			n->op = Cast_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float32;
+			n->op = Cast_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Cast_init;
 			n->exit = Cast_exit;
 			n->reshape = Cast_reshape;
-			n->operator = Cast_float64;
+			n->op = Cast_float64;
 			break;
 		default:
 			break;

--- a/src/default/Ceil.c
+++ b/src/default/Ceil.c
@@ -82,25 +82,25 @@ void resolver_default_op_Ceil(struct onnx_node_t * n)
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_bfloat16;
+			n->op = Ceil_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float16;
+			n->op = Ceil_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float32;
+			n->op = Ceil_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float64;
+			n->op = Ceil_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Ceil(struct onnx_node_t * n)
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float16;
+			n->op = Ceil_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float32;
+			n->op = Ceil_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float64;
+			n->op = Ceil_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Ceil(struct onnx_node_t * n)
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float16;
+			n->op = Ceil_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float32;
+			n->op = Ceil_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Ceil_init;
 			n->exit = Ceil_exit;
 			n->reshape = Ceil_reshape;
-			n->operator = Ceil_float64;
+			n->op = Ceil_float64;
 			break;
 		default:
 			break;

--- a/src/default/Celu.c
+++ b/src/default/Celu.c
@@ -60,7 +60,7 @@ void resolver_default_op_Celu(struct onnx_node_t * n)
 			n->init = Celu_init;
 			n->exit = Celu_exit;
 			n->reshape = Celu_reshape;
-			n->operator = Celu_float32;
+			n->op = Celu_float32;
 			break;
 		default:
 			break;

--- a/src/default/Clip.c
+++ b/src/default/Clip.c
@@ -346,73 +346,73 @@ void resolver_default_op_Clip(struct onnx_node_t * n)
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int8;
+			n->op = Clip_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int16;
+			n->op = Clip_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int32;
+			n->op = Clip_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int64;
+			n->op = Clip_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint8;
+			n->op = Clip_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint16;
+			n->op = Clip_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint32;
+			n->op = Clip_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint64;
+			n->op = Clip_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_bfloat16;
+			n->op = Clip_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float16;
+			n->op = Clip_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float32;
+			n->op = Clip_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float64;
+			n->op = Clip_float64;
 			break;
 		default:
 			break;
@@ -426,67 +426,67 @@ void resolver_default_op_Clip(struct onnx_node_t * n)
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int8;
+			n->op = Clip_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int16;
+			n->op = Clip_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int32;
+			n->op = Clip_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_int64;
+			n->op = Clip_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint8;
+			n->op = Clip_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint16;
+			n->op = Clip_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint32;
+			n->op = Clip_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_uint64;
+			n->op = Clip_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float16;
+			n->op = Clip_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float32;
+			n->op = Clip_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float64;
+			n->op = Clip_float64;
 			break;
 		default:
 			break;
@@ -500,19 +500,19 @@ void resolver_default_op_Clip(struct onnx_node_t * n)
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float16;
+			n->op = Clip_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float32;
+			n->op = Clip_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Clip_init;
 			n->exit = Clip_exit;
 			n->reshape = Clip_reshape;
-			n->operator = Clip_float64;
+			n->op = Clip_float64;
 			break;
 		default:
 			break;

--- a/src/default/Concat.c
+++ b/src/default/Concat.c
@@ -156,7 +156,7 @@ void resolver_default_op_Concat(struct onnx_node_t * n)
 			n->init = Concat_init;
 			n->exit = Concat_exit;
 			n->reshape = Concat_reshape;
-			n->operator = Concat_operator;
+			n->op = Concat_operator;
 			break;
 		default:
 			break;
@@ -184,7 +184,7 @@ void resolver_default_op_Concat(struct onnx_node_t * n)
 			n->init = Concat_init;
 			n->exit = Concat_exit;
 			n->reshape = Concat_reshape;
-			n->operator = Concat_operator;
+			n->op = Concat_operator;
 			break;
 		default:
 			break;
@@ -212,7 +212,7 @@ void resolver_default_op_Concat(struct onnx_node_t * n)
 			n->init = Concat_init;
 			n->exit = Concat_exit;
 			n->reshape = Concat_reshape;
-			n->operator = Concat_operator;
+			n->op = Concat_operator;
 			break;
 		default:
 			break;
@@ -228,7 +228,7 @@ void resolver_default_op_Concat(struct onnx_node_t * n)
 			n->init = Concat_init;
 			n->exit = Concat_exit;
 			n->reshape = Concat_reshape;
-			n->operator = Concat_operator;
+			n->op = Concat_operator;
 			break;
 		default:
 			break;

--- a/src/default/Constant.c
+++ b/src/default/Constant.c
@@ -115,34 +115,34 @@ void resolver_default_op_Constant(struct onnx_node_t * n)
 		n->init = Constant_init;
 		n->exit = Constant_exit;
 		n->reshape = Constant_reshape;
-		n->operator = Constant_operator;
+		n->op = Constant_operator;
 	}
 	else if(n->opset >= 12)
 	{
 		n->init = Constant_init;
 		n->exit = Constant_exit;
 		n->reshape = Constant_reshape;
-		n->operator = Constant_operator;
+		n->op = Constant_operator;
 	}
 	else if(n->opset >= 11)
 	{
 		n->init = Constant_init;
 		n->exit = Constant_exit;
 		n->reshape = Constant_reshape;
-		n->operator = Constant_operator;
+		n->op = Constant_operator;
 	}
 	else if(n->opset >= 9)
 	{
 		n->init = Constant_init;
 		n->exit = Constant_exit;
 		n->reshape = Constant_reshape;
-		n->operator = Constant_operator;
+		n->op = Constant_operator;
 	}
 	else if(n->opset >= 1)
 	{
 		n->init = Constant_init;
 		n->exit = Constant_exit;
 		n->reshape = Constant_reshape;
-		n->operator = Constant_operator;
+		n->op = Constant_operator;
 	}
 }

--- a/src/default/ConstantOfShape.c
+++ b/src/default/ConstantOfShape.c
@@ -165,6 +165,6 @@ void resolver_default_op_ConstantOfShape(struct onnx_node_t * n)
 		n->init = ConstantOfShape_init;
 		n->exit = ConstantOfShape_exit;
 		n->reshape = ConstantOfShape_reshape;
-		n->operator = ConstantOfShape_operator;
+		n->op = ConstantOfShape_operator;
 	}
 }

--- a/src/default/Conv.c
+++ b/src/default/Conv.c
@@ -1134,19 +1134,19 @@ void resolver_default_op_Conv(struct onnx_node_t * n)
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float16;
+			n->op = Conv_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float32;
+			n->op = Conv_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float64;
+			n->op = Conv_float64;
 			break;
 		default:
 			break;
@@ -1160,19 +1160,19 @@ void resolver_default_op_Conv(struct onnx_node_t * n)
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float16;
+			n->op = Conv_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float32;
+			n->op = Conv_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Conv_init;
 			n->exit = Conv_exit;
 			n->reshape = Conv_reshape;
-			n->operator = Conv_float64;
+			n->op = Conv_float64;
 			break;
 		default:
 			break;

--- a/src/default/Cos.c
+++ b/src/default/Cos.c
@@ -67,19 +67,19 @@ void resolver_default_op_Cos(struct onnx_node_t * n)
 			n->init = Cos_init;
 			n->exit = Cos_exit;
 			n->reshape = Cos_reshape;
-			n->operator = Cos_float16;
+			n->op = Cos_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Cos_init;
 			n->exit = Cos_exit;
 			n->reshape = Cos_reshape;
-			n->operator = Cos_float32;
+			n->op = Cos_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Cos_init;
 			n->exit = Cos_exit;
 			n->reshape = Cos_reshape;
-			n->operator = Cos_float64;
+			n->op = Cos_float64;
 			break;
 		default:
 			break;

--- a/src/default/Cosh.c
+++ b/src/default/Cosh.c
@@ -67,19 +67,19 @@ void resolver_default_op_Cosh(struct onnx_node_t * n)
 			n->init = Cosh_init;
 			n->exit = Cosh_exit;
 			n->reshape = Cosh_reshape;
-			n->operator = Cosh_float16;
+			n->op = Cosh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Cosh_init;
 			n->exit = Cosh_exit;
 			n->reshape = Cosh_reshape;
-			n->operator = Cosh_float32;
+			n->op = Cosh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Cosh_init;
 			n->exit = Cosh_exit;
 			n->reshape = Cosh_reshape;
-			n->operator = Cosh_float64;
+			n->op = Cosh_float64;
 			break;
 		default:
 			break;

--- a/src/default/Div.c
+++ b/src/default/Div.c
@@ -235,73 +235,73 @@ void resolver_default_op_Div(struct onnx_node_t * n)
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int8;
+			n->op = Div_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int16;
+			n->op = Div_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int32;
+			n->op = Div_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int64;
+			n->op = Div_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint8;
+			n->op = Div_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint16;
+			n->op = Div_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint32;
+			n->op = Div_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint64;
+			n->op = Div_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_13_bfloat16;
+			n->op = Div_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float16;
+			n->op = Div_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float32;
+			n->op = Div_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float64;
+			n->op = Div_float64;
 			break;
 		default:
 			break;
@@ -315,49 +315,49 @@ void resolver_default_op_Div(struct onnx_node_t * n)
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int32;
+			n->op = Div_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int64;
+			n->op = Div_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint32;
+			n->op = Div_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint64;
+			n->op = Div_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_13_bfloat16;
+			n->op = Div_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float16;
+			n->op = Div_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float32;
+			n->op = Div_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float64;
+			n->op = Div_float64;
 			break;
 		default:
 			break;
@@ -371,43 +371,43 @@ void resolver_default_op_Div(struct onnx_node_t * n)
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int32;
+			n->op = Div_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_int64;
+			n->op = Div_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint32;
+			n->op = Div_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_uint64;
+			n->op = Div_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float16;
+			n->op = Div_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float32;
+			n->op = Div_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Div_init;
 			n->exit = Div_exit;
 			n->reshape = Div_reshape;
-			n->operator = Div_float64;
+			n->op = Div_float64;
 			break;
 		default:
 			break;

--- a/src/default/Dropout.c
+++ b/src/default/Dropout.c
@@ -74,25 +74,25 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_bfloat16;
+			n->op = Dropout_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;
@@ -106,19 +106,19 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;
@@ -132,19 +132,19 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;
@@ -158,19 +158,19 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;
@@ -184,19 +184,19 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;
@@ -210,19 +210,19 @@ void resolver_default_op_Dropout(struct onnx_node_t * n)
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float16;
+			n->op = Dropout_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float32;
+			n->op = Dropout_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Dropout_init;
 			n->exit = Dropout_exit;
 			n->reshape = Dropout_reshape;
-			n->operator = Dropout_float64;
+			n->op = Dropout_float64;
 			break;
 		default:
 			break;

--- a/src/default/Elu.c
+++ b/src/default/Elu.c
@@ -88,19 +88,19 @@ void resolver_default_op_Elu(struct onnx_node_t * n)
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float16;
+			n->op = Elu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float32;
+			n->op = Elu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float64;
+			n->op = Elu_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Elu(struct onnx_node_t * n)
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float16;
+			n->op = Elu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float32;
+			n->op = Elu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Elu_init;
 			n->exit = Elu_exit;
 			n->reshape = Elu_reshape;
-			n->operator = Elu_float64;
+			n->op = Elu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Equal.c
+++ b/src/default/Equal.c
@@ -252,79 +252,79 @@ void resolver_default_op_Equal(struct onnx_node_t * n)
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_bool;
+			n->op = Equal_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int8;
+			n->op = Equal_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int16;
+			n->op = Equal_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int32;
+			n->op = Equal_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int64;
+			n->op = Equal_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint8;
+			n->op = Equal_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint16;
+			n->op = Equal_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint32;
+			n->op = Equal_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint64;
+			n->op = Equal_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_bfloat16;
+			n->op = Equal_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float16;
+			n->op = Equal_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float32;
+			n->op = Equal_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float64;
+			n->op = Equal_float64;
 			break;
 		default:
 			break;
@@ -338,73 +338,73 @@ void resolver_default_op_Equal(struct onnx_node_t * n)
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_bool;
+			n->op = Equal_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int8;
+			n->op = Equal_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int16;
+			n->op = Equal_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int32;
+			n->op = Equal_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int64;
+			n->op = Equal_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint8;
+			n->op = Equal_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint16;
+			n->op = Equal_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint32;
+			n->op = Equal_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_uint64;
+			n->op = Equal_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float16;
+			n->op = Equal_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float32;
+			n->op = Equal_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_float64;
+			n->op = Equal_float64;
 			break;
 		default:
 			break;
@@ -418,19 +418,19 @@ void resolver_default_op_Equal(struct onnx_node_t * n)
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_bool;
+			n->op = Equal_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int32;
+			n->op = Equal_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Equal_init;
 			n->exit = Equal_exit;
 			n->reshape = Equal_reshape;
-			n->operator = Equal_int64;
+			n->op = Equal_int64;
 			break;
 		default:
 			break;

--- a/src/default/Erf.c
+++ b/src/default/Erf.c
@@ -178,73 +178,73 @@ void resolver_default_op_Erf(struct onnx_node_t * n)
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int8;
+			n->op = Erf_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int16;
+			n->op = Erf_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int32;
+			n->op = Erf_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int64;
+			n->op = Erf_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint8;
+			n->op = Erf_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint16;
+			n->op = Erf_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint32;
+			n->op = Erf_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint64;
+			n->op = Erf_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_bfloat16;
+			n->op = Erf_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float16;
+			n->op = Erf_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float32;
+			n->op = Erf_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float64;
+			n->op = Erf_float64;
 			break;
 		default:
 			break;
@@ -258,67 +258,67 @@ void resolver_default_op_Erf(struct onnx_node_t * n)
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int8;
+			n->op = Erf_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int16;
+			n->op = Erf_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int32;
+			n->op = Erf_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_int64;
+			n->op = Erf_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint8;
+			n->op = Erf_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint16;
+			n->op = Erf_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint32;
+			n->op = Erf_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_uint64;
+			n->op = Erf_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float16;
+			n->op = Erf_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float32;
+			n->op = Erf_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Erf_init;
 			n->exit = Erf_exit;
 			n->reshape = Erf_reshape;
-			n->operator = Erf_float64;
+			n->op = Erf_float64;
 			break;
 		default:
 			break;

--- a/src/default/Exp.c
+++ b/src/default/Exp.c
@@ -82,25 +82,25 @@ void resolver_default_op_Exp(struct onnx_node_t * n)
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_bfloat16;
+			n->op = Exp_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float16;
+			n->op = Exp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float32;
+			n->op = Exp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float64;
+			n->op = Exp_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Exp(struct onnx_node_t * n)
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float16;
+			n->op = Exp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float32;
+			n->op = Exp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float64;
+			n->op = Exp_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Exp(struct onnx_node_t * n)
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float16;
+			n->op = Exp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float32;
+			n->op = Exp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Exp_init;
 			n->exit = Exp_exit;
 			n->reshape = Exp_reshape;
-			n->operator = Exp_float64;
+			n->op = Exp_float64;
 			break;
 		default:
 			break;

--- a/src/default/Expand.c
+++ b/src/default/Expand.c
@@ -281,97 +281,97 @@ void resolver_default_op_Expand(struct onnx_node_t * n)
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_bool;
+			n->op = Expand_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int8;
+			n->op = Expand_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int16;
+			n->op = Expand_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int32;
+			n->op = Expand_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int64;
+			n->op = Expand_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint8;
+			n->op = Expand_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint16;
+			n->op = Expand_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint32;
+			n->op = Expand_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint64;
+			n->op = Expand_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_bfloat16;
+			n->op = Expand_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float16;
+			n->op = Expand_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float32;
+			n->op = Expand_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float64;
+			n->op = Expand_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_complex64;
+			n->op = Expand_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_complex128;
+			n->op = Expand_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_string;
+			n->op = Expand_string;
 			break;
 		default:
 			break;
@@ -385,91 +385,91 @@ void resolver_default_op_Expand(struct onnx_node_t * n)
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_bool;
+			n->op = Expand_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int8;
+			n->op = Expand_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int16;
+			n->op = Expand_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int32;
+			n->op = Expand_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_int64;
+			n->op = Expand_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint8;
+			n->op = Expand_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint16;
+			n->op = Expand_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint32;
+			n->op = Expand_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_uint64;
+			n->op = Expand_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float16;
+			n->op = Expand_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float32;
+			n->op = Expand_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_float64;
+			n->op = Expand_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_complex64;
+			n->op = Expand_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_complex128;
+			n->op = Expand_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Expand_init;
 			n->exit = Expand_exit;
 			n->reshape = Expand_reshape;
-			n->operator = Expand_string;
+			n->op = Expand_string;
 			break;
 		default:
 			break;

--- a/src/default/Flatten.c
+++ b/src/default/Flatten.c
@@ -105,7 +105,7 @@ void resolver_default_op_Flatten(struct onnx_node_t * n)
 			n->init = Flatten_init;
 			n->exit = Flatten_exit;
 			n->reshape = Flatten_reshape;
-			n->operator = Flatten_operator;
+			n->op = Flatten_operator;
 			break;
 		default:
 			break;
@@ -133,7 +133,7 @@ void resolver_default_op_Flatten(struct onnx_node_t * n)
 			n->init = Flatten_init;
 			n->exit = Flatten_exit;
 			n->reshape = Flatten_reshape;
-			n->operator = Flatten_operator;
+			n->op = Flatten_operator;
 			break;
 		default:
 			break;
@@ -161,7 +161,7 @@ void resolver_default_op_Flatten(struct onnx_node_t * n)
 			n->init = Flatten_init;
 			n->exit = Flatten_exit;
 			n->reshape = Flatten_reshape;
-			n->operator = Flatten_operator;
+			n->op = Flatten_operator;
 			break;
 		default:
 			break;
@@ -177,7 +177,7 @@ void resolver_default_op_Flatten(struct onnx_node_t * n)
 			n->init = Flatten_init;
 			n->exit = Flatten_exit;
 			n->reshape = Flatten_reshape;
-			n->operator = Flatten_operator;
+			n->op = Flatten_operator;
 			break;
 		default:
 			break;

--- a/src/default/Floor.c
+++ b/src/default/Floor.c
@@ -82,25 +82,25 @@ void resolver_default_op_Floor(struct onnx_node_t * n)
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_bfloat16;
+			n->op = Floor_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float16;
+			n->op = Floor_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float32;
+			n->op = Floor_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float64;
+			n->op = Floor_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Floor(struct onnx_node_t * n)
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float16;
+			n->op = Floor_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float32;
+			n->op = Floor_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float64;
+			n->op = Floor_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Floor(struct onnx_node_t * n)
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float16;
+			n->op = Floor_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float32;
+			n->op = Floor_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Floor_init;
 			n->exit = Floor_exit;
 			n->reshape = Floor_reshape;
-			n->operator = Floor_float64;
+			n->op = Floor_float64;
 			break;
 		default:
 			break;

--- a/src/default/Gemm.c
+++ b/src/default/Gemm.c
@@ -1170,49 +1170,49 @@ void resolver_default_op_Gemm(struct onnx_node_t * n)
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int32;
+			n->op = Gemm_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int64;
+			n->op = Gemm_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint32;
+			n->op = Gemm_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint64;
+			n->op = Gemm_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_bfloat16;
+			n->op = Gemm_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float16;
+			n->op = Gemm_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float32;
+			n->op = Gemm_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float64;
+			n->op = Gemm_float64;
 			break;
 		default:
 			break;
@@ -1226,43 +1226,43 @@ void resolver_default_op_Gemm(struct onnx_node_t * n)
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int32;
+			n->op = Gemm_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int64;
+			n->op = Gemm_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint32;
+			n->op = Gemm_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint64;
+			n->op = Gemm_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float16;
+			n->op = Gemm_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float32;
+			n->op = Gemm_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float64;
+			n->op = Gemm_float64;
 			break;
 		default:
 			break;
@@ -1276,43 +1276,43 @@ void resolver_default_op_Gemm(struct onnx_node_t * n)
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int32;
+			n->op = Gemm_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_int64;
+			n->op = Gemm_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint32;
+			n->op = Gemm_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_uint64;
+			n->op = Gemm_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float16;
+			n->op = Gemm_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float32;
+			n->op = Gemm_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float64;
+			n->op = Gemm_float64;
 			break;
 		default:
 			break;
@@ -1326,19 +1326,19 @@ void resolver_default_op_Gemm(struct onnx_node_t * n)
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float16;
+			n->op = Gemm_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float32;
+			n->op = Gemm_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Gemm_init;
 			n->exit = Gemm_exit;
 			n->reshape = Gemm_reshape;
-			n->operator = Gemm_float64;
+			n->op = Gemm_float64;
 			break;
 		default:
 			break;

--- a/src/default/GlobalAveragePool.c
+++ b/src/default/GlobalAveragePool.c
@@ -130,19 +130,19 @@ void resolver_default_op_GlobalAveragePool(struct onnx_node_t * n)
 			n->init = GlobalAveragePool_init;
 			n->exit = GlobalAveragePool_exit;
 			n->reshape = GlobalAveragePool_reshape;
-			n->operator = GlobalAveragePool_float16;
+			n->op = GlobalAveragePool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = GlobalAveragePool_init;
 			n->exit = GlobalAveragePool_exit;
 			n->reshape = GlobalAveragePool_reshape;
-			n->operator = GlobalAveragePool_float32;
+			n->op = GlobalAveragePool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = GlobalAveragePool_init;
 			n->exit = GlobalAveragePool_exit;
 			n->reshape = GlobalAveragePool_reshape;
-			n->operator = GlobalAveragePool_float64;
+			n->op = GlobalAveragePool_float64;
 			break;
 		default:
 			break;

--- a/src/default/GlobalLpPool.c
+++ b/src/default/GlobalLpPool.c
@@ -134,19 +134,19 @@ void resolver_default_op_GlobalLpPool(struct onnx_node_t * n)
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float16;
+			n->op = GlobalLpPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float32;
+			n->op = GlobalLpPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float64;
+			n->op = GlobalLpPool_float64;
 			break;
 		default:
 			break;
@@ -160,19 +160,19 @@ void resolver_default_op_GlobalLpPool(struct onnx_node_t * n)
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float16;
+			n->op = GlobalLpPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float32;
+			n->op = GlobalLpPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = GlobalLpPool_init;
 			n->exit = GlobalLpPool_exit;
 			n->reshape = GlobalLpPool_reshape;
-			n->operator = GlobalLpPool_float64;
+			n->op = GlobalLpPool_float64;
 			break;
 		default:
 			break;

--- a/src/default/GlobalMaxPool.c
+++ b/src/default/GlobalMaxPool.c
@@ -111,19 +111,19 @@ void resolver_default_op_GlobalMaxPool(struct onnx_node_t * n)
 			n->init = GlobalMaxPool_init;
 			n->exit = GlobalMaxPool_exit;
 			n->reshape = GlobalMaxPool_reshape;
-			n->operator = GlobalMaxPool_float16;
+			n->op = GlobalMaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = GlobalMaxPool_init;
 			n->exit = GlobalMaxPool_exit;
 			n->reshape = GlobalMaxPool_reshape;
-			n->operator = GlobalMaxPool_float32;
+			n->op = GlobalMaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = GlobalMaxPool_init;
 			n->exit = GlobalMaxPool_exit;
 			n->reshape = GlobalMaxPool_reshape;
-			n->operator = GlobalMaxPool_float64;
+			n->op = GlobalMaxPool_float64;
 			break;
 		default:
 			break;

--- a/src/default/Greater.c
+++ b/src/default/Greater.c
@@ -235,73 +235,73 @@ void resolver_default_op_Greater(struct onnx_node_t * n)
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int8;
+			n->op = Greater_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int16;
+			n->op = Greater_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int32;
+			n->op = Greater_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int64;
+			n->op = Greater_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint8;
+			n->op = Greater_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint16;
+			n->op = Greater_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint32;
+			n->op = Greater_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint64;
+			n->op = Greater_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_bfloat16;
+			n->op = Greater_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float16;
+			n->op = Greater_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float32;
+			n->op = Greater_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float64;
+			n->op = Greater_float64;
 			break;
 		default:
 			break;
@@ -315,67 +315,67 @@ void resolver_default_op_Greater(struct onnx_node_t * n)
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int8;
+			n->op = Greater_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int16;
+			n->op = Greater_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int32;
+			n->op = Greater_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_int64;
+			n->op = Greater_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint8;
+			n->op = Greater_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint16;
+			n->op = Greater_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint32;
+			n->op = Greater_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_uint64;
+			n->op = Greater_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float16;
+			n->op = Greater_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float32;
+			n->op = Greater_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float64;
+			n->op = Greater_float64;
 			break;
 		default:
 			break;
@@ -389,19 +389,19 @@ void resolver_default_op_Greater(struct onnx_node_t * n)
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float16;
+			n->op = Greater_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float32;
+			n->op = Greater_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Greater_init;
 			n->exit = Greater_exit;
 			n->reshape = Greater_reshape;
-			n->operator = Greater_float64;
+			n->op = Greater_float64;
 			break;
 		default:
 			break;

--- a/src/default/GreaterOrEqual.c
+++ b/src/default/GreaterOrEqual.c
@@ -218,67 +218,67 @@ void resolver_default_op_GreaterOrEqual(struct onnx_node_t * n)
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_int8;
+			n->op = GreaterOrEqual_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_int16;
+			n->op = GreaterOrEqual_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_int32;
+			n->op = GreaterOrEqual_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_int64;
+			n->op = GreaterOrEqual_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_uint8;
+			n->op = GreaterOrEqual_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_uint16;
+			n->op = GreaterOrEqual_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_uint32;
+			n->op = GreaterOrEqual_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_uint64;
+			n->op = GreaterOrEqual_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_float16;
+			n->op = GreaterOrEqual_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_float32;
+			n->op = GreaterOrEqual_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = GreaterOrEqual_init;
 			n->exit = GreaterOrEqual_exit;
 			n->reshape = GreaterOrEqual_reshape;
-			n->operator = GreaterOrEqual_float64;
+			n->op = GreaterOrEqual_float64;
 			break;
 		default:
 			break;

--- a/src/default/HardSigmoid.c
+++ b/src/default/HardSigmoid.c
@@ -90,19 +90,19 @@ void resolver_default_op_HardSigmoid(struct onnx_node_t * n)
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float16;
+			n->op = HardSigmoid_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float32;
+			n->op = HardSigmoid_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float64;
+			n->op = HardSigmoid_float64;
 			break;
 		default:
 			break;
@@ -116,19 +116,19 @@ void resolver_default_op_HardSigmoid(struct onnx_node_t * n)
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float16;
+			n->op = HardSigmoid_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float32;
+			n->op = HardSigmoid_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = HardSigmoid_init;
 			n->exit = HardSigmoid_exit;
 			n->reshape = HardSigmoid_reshape;
-			n->operator = HardSigmoid_float64;
+			n->op = HardSigmoid_float64;
 			break;
 		default:
 			break;

--- a/src/default/Identity.c
+++ b/src/default/Identity.c
@@ -67,7 +67,7 @@ void resolver_default_op_Identity(struct onnx_node_t * n)
 			n->init = Identity_init;
 			n->exit = Identity_exit;
 			n->reshape = Identity_reshape;
-			n->operator = Identity_operator;
+			n->op = Identity_operator;
 			break;
 		default:
 			break;
@@ -96,7 +96,7 @@ void resolver_default_op_Identity(struct onnx_node_t * n)
 			n->init = Identity_init;
 			n->exit = Identity_exit;
 			n->reshape = Identity_reshape;
-			n->operator = Identity_operator;
+			n->op = Identity_operator;
 			break;
 		default:
 			break;
@@ -124,7 +124,7 @@ void resolver_default_op_Identity(struct onnx_node_t * n)
 			n->init = Identity_init;
 			n->exit = Identity_exit;
 			n->reshape = Identity_reshape;
-			n->operator = Identity_operator;
+			n->op = Identity_operator;
 			break;
 		default:
 			break;

--- a/src/default/If.c
+++ b/src/default/If.c
@@ -98,7 +98,7 @@ static void If_operator(struct onnx_node_t * n)
 		for(i = 0; i < g->nlen; i++)
 		{
 			t = &g->nodes[i];
-			t->operator(t);
+			t->op(t);
 		}
 		if(t)
 		{
@@ -133,20 +133,20 @@ void resolver_default_op_If(struct onnx_node_t * n)
 		n->init = If_init;
 		n->exit = If_exit;
 		n->reshape = If_reshape;
-		n->operator = If_operator;
+		n->op = If_operator;
 	}
 	else if(n->opset >= 11)
 	{
 		n->init = If_init;
 		n->exit = If_exit;
 		n->reshape = If_reshape;
-		n->operator = If_operator;
+		n->op = If_operator;
 	}
 	else if(n->opset >= 1)
 	{
 		n->init = If_init;
 		n->exit = If_exit;
 		n->reshape = If_reshape;
-		n->operator = If_operator;
+		n->op = If_operator;
 	}
 }

--- a/src/default/InstanceNormalization.c
+++ b/src/default/InstanceNormalization.c
@@ -162,19 +162,19 @@ void resolver_default_op_InstanceNormalization(struct onnx_node_t * n)
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float16;
+			n->op = InstanceNormalization_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float32;
+			n->op = InstanceNormalization_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float64;
+			n->op = InstanceNormalization_float64;
 			break;
 		default:
 			break;
@@ -188,19 +188,19 @@ void resolver_default_op_InstanceNormalization(struct onnx_node_t * n)
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float16;
+			n->op = InstanceNormalization_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float32;
+			n->op = InstanceNormalization_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = InstanceNormalization_init;
 			n->exit = InstanceNormalization_exit;
 			n->reshape = InstanceNormalization_reshape;
-			n->operator = InstanceNormalization_float64;
+			n->op = InstanceNormalization_float64;
 			break;
 		default:
 			break;

--- a/src/default/IsInf.c
+++ b/src/default/IsInf.c
@@ -98,13 +98,13 @@ void resolver_default_op_IsInf(struct onnx_node_t * n)
 			n->init = IsInf_init;
 			n->exit = IsInf_exit;
 			n->reshape = IsInf_reshape;
-			n->operator = IsInf_float32;
+			n->op = IsInf_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = IsInf_init;
 			n->exit = IsInf_exit;
 			n->reshape = IsInf_reshape;
-			n->operator = IsInf_float64;
+			n->op = IsInf_float64;
 			break;
 		default:
 			break;

--- a/src/default/IsNaN.c
+++ b/src/default/IsNaN.c
@@ -82,25 +82,25 @@ void resolver_default_op_IsNaN(struct onnx_node_t * n)
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_bfloat16;
+			n->op = IsNaN_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float16;
+			n->op = IsNaN_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float32;
+			n->op = IsNaN_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float64;
+			n->op = IsNaN_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_IsNaN(struct onnx_node_t * n)
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float16;
+			n->op = IsNaN_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float32;
+			n->op = IsNaN_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = IsNaN_init;
 			n->exit = IsNaN_exit;
 			n->reshape = IsNaN_reshape;
-			n->operator = IsNaN_float64;
+			n->op = IsNaN_float64;
 			break;
 		default:
 			break;

--- a/src/default/LRN.c
+++ b/src/default/LRN.c
@@ -210,25 +210,25 @@ void resolver_default_op_LRN(struct onnx_node_t * n)
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_bfloat16;
+			n->op = LRN_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float16;
+			n->op = LRN_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float32;
+			n->op = LRN_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float64;
+			n->op = LRN_float64;
 			break;
 		default:
 			break;
@@ -242,19 +242,19 @@ void resolver_default_op_LRN(struct onnx_node_t * n)
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float16;
+			n->op = LRN_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float32;
+			n->op = LRN_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LRN_init;
 			n->exit = LRN_exit;
 			n->reshape = LRN_reshape;
-			n->operator = LRN_float64;
+			n->op = LRN_float64;
 			break;
 		default:
 			break;

--- a/src/default/LeakyRelu.c
+++ b/src/default/LeakyRelu.c
@@ -90,19 +90,19 @@ void resolver_default_op_LeakyRelu(struct onnx_node_t * n)
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float16;
+			n->op = LeakyRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float32;
+			n->op = LeakyRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float64;
+			n->op = LeakyRelu_float64;
 			break;
 		default:
 			break;
@@ -116,19 +116,19 @@ void resolver_default_op_LeakyRelu(struct onnx_node_t * n)
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float16;
+			n->op = LeakyRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float32;
+			n->op = LeakyRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LeakyRelu_init;
 			n->exit = LeakyRelu_exit;
 			n->reshape = LeakyRelu_reshape;
-			n->operator = LeakyRelu_float64;
+			n->op = LeakyRelu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Less.c
+++ b/src/default/Less.c
@@ -235,73 +235,73 @@ void resolver_default_op_Less(struct onnx_node_t * n)
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int8;
+			n->op = Less_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int16;
+			n->op = Less_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int32;
+			n->op = Less_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int64;
+			n->op = Less_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint8;
+			n->op = Less_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint16;
+			n->op = Less_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint32;
+			n->op = Less_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint64;
+			n->op = Less_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_bfloat16;
+			n->op = Less_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float16;
+			n->op = Less_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float32;
+			n->op = Less_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float64;
+			n->op = Less_float64;
 			break;
 		default:
 			break;
@@ -315,67 +315,67 @@ void resolver_default_op_Less(struct onnx_node_t * n)
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int8;
+			n->op = Less_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int16;
+			n->op = Less_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int32;
+			n->op = Less_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_int64;
+			n->op = Less_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint8;
+			n->op = Less_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint16;
+			n->op = Less_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint32;
+			n->op = Less_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_uint64;
+			n->op = Less_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float16;
+			n->op = Less_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float32;
+			n->op = Less_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float64;
+			n->op = Less_float64;
 			break;
 		default:
 			break;
@@ -389,19 +389,19 @@ void resolver_default_op_Less(struct onnx_node_t * n)
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float16;
+			n->op = Less_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float32;
+			n->op = Less_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Less_init;
 			n->exit = Less_exit;
 			n->reshape = Less_reshape;
-			n->operator = Less_float64;
+			n->op = Less_float64;
 			break;
 		default:
 			break;

--- a/src/default/LessOrEqual.c
+++ b/src/default/LessOrEqual.c
@@ -218,66 +218,66 @@ void resolver_default_op_LessOrEqual(struct onnx_node_t * n)
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_int8;
+			n->op = LessOrEqual_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_int16;
+			n->op = LessOrEqual_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_int32;
+			n->op = LessOrEqual_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_int64;
+			n->op = LessOrEqual_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_uint8;
+			n->op = LessOrEqual_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_uint16;
+			n->op = LessOrEqual_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_uint32;
+			n->op = LessOrEqual_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
-			n->operator = LessOrEqual_uint64;
+			n->op = LessOrEqual_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_float16;
+			n->op = LessOrEqual_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_float32;
+			n->op = LessOrEqual_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LessOrEqual_init;
 			n->exit = LessOrEqual_exit;
 			n->reshape = LessOrEqual_reshape;
-			n->operator = LessOrEqual_float64;
+			n->op = LessOrEqual_float64;
 			break;
 		default:
 			break;

--- a/src/default/Log.c
+++ b/src/default/Log.c
@@ -82,25 +82,25 @@ void resolver_default_op_Log(struct onnx_node_t * n)
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_bfloat16;
+			n->op = Log_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float16;
+			n->op = Log_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float32;
+			n->op = Log_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float64;
+			n->op = Log_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Log(struct onnx_node_t * n)
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float16;
+			n->op = Log_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float32;
+			n->op = Log_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float64;
+			n->op = Log_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Log(struct onnx_node_t * n)
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float16;
+			n->op = Log_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float32;
+			n->op = Log_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Log_init;
 			n->exit = Log_exit;
 			n->reshape = Log_reshape;
-			n->operator = Log_float64;
+			n->op = Log_float64;
 			break;
 		default:
 			break;

--- a/src/default/LogSoftmax.c
+++ b/src/default/LogSoftmax.c
@@ -386,25 +386,25 @@ void resolver_default_op_LogSoftmax(struct onnx_node_t * n)
 			n->init = LogSoftmax_13_init;
 			n->exit = LogSoftmax_13_exit;
 			n->reshape = LogSoftmax_13_reshape;
-			n->operator = LogSoftmax_13_bfloat16;
+			n->op = LogSoftmax_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = LogSoftmax_13_init;
 			n->exit = LogSoftmax_13_exit;
 			n->reshape = LogSoftmax_13_reshape;
-			n->operator = LogSoftmax_13_float16;
+			n->op = LogSoftmax_13_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LogSoftmax_13_init;
 			n->exit = LogSoftmax_13_exit;
 			n->reshape = LogSoftmax_13_reshape;
-			n->operator = LogSoftmax_13_float32;
+			n->op = LogSoftmax_13_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LogSoftmax_13_init;
 			n->exit = LogSoftmax_13_exit;
 			n->reshape = LogSoftmax_13_reshape;
-			n->operator = LogSoftmax_13_float64;
+			n->op = LogSoftmax_13_float64;
 			break;
 		default:
 			break;
@@ -418,19 +418,19 @@ void resolver_default_op_LogSoftmax(struct onnx_node_t * n)
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float16;
+			n->op = LogSoftmax_1_11_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float32;
+			n->op = LogSoftmax_1_11_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float64;
+			n->op = LogSoftmax_1_11_float64;
 			break;
 		default:
 			break;
@@ -444,19 +444,19 @@ void resolver_default_op_LogSoftmax(struct onnx_node_t * n)
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float16;
+			n->op = LogSoftmax_1_11_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float32;
+			n->op = LogSoftmax_1_11_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = LogSoftmax_1_11_init;
 			n->exit = LogSoftmax_1_11_exit;
 			n->reshape = LogSoftmax_1_11_reshape;
-			n->operator = LogSoftmax_1_11_float64;
+			n->op = LogSoftmax_1_11_float64;
 			break;
 		default:
 			break;

--- a/src/default/MatMul.c
+++ b/src/default/MatMul.c
@@ -321,49 +321,49 @@ void resolver_default_op_MatMul(struct onnx_node_t * n)
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_int32;
+			n->op = MatMul_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_int64;
+			n->op = MatMul_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_uint32;
+			n->op = MatMul_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_uint64;
+			n->op = MatMul_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_bfloat16;
+			n->op = MatMul_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float16;
+			n->op = MatMul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float32;
+			n->op = MatMul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float64;
+			n->op = MatMul_float64;
 			break;
 		default:
 			break;
@@ -377,43 +377,43 @@ void resolver_default_op_MatMul(struct onnx_node_t * n)
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_int32;
+			n->op = MatMul_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_int64;
+			n->op = MatMul_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_uint32;
+			n->op = MatMul_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_uint64;
+			n->op = MatMul_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float16;
+			n->op = MatMul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float32;
+			n->op = MatMul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float64;
+			n->op = MatMul_float64;
 			break;
 		default:
 			break;
@@ -427,19 +427,19 @@ void resolver_default_op_MatMul(struct onnx_node_t * n)
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float16;
+			n->op = MatMul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float32;
+			n->op = MatMul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MatMul_init;
 			n->exit = MatMul_exit;
 			n->reshape = MatMul_reshape;
-			n->operator = MatMul_float64;
+			n->op = MatMul_float64;
 			break;
 		default:
 			break;

--- a/src/default/Max.c
+++ b/src/default/Max.c
@@ -305,73 +305,73 @@ void resolver_default_op_Max(struct onnx_node_t * n)
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int8;
+			n->op = Max_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int16;
+			n->op = Max_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int32;
+			n->op = Max_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int64;
+			n->op = Max_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint8;
+			n->op = Max_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint16;
+			n->op = Max_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint32;
+			n->op = Max_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint64;
+			n->op = Max_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_bfloat16;
+			n->op = Max_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float16;
+			n->op = Max_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float32;
+			n->op = Max_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float64;
+			n->op = Max_float64;
 			break;
 		default:
 			break;
@@ -385,67 +385,67 @@ void resolver_default_op_Max(struct onnx_node_t * n)
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int8;
+			n->op = Max_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int16;
+			n->op = Max_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int32;
+			n->op = Max_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_int64;
+			n->op = Max_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint8;
+			n->op = Max_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint16;
+			n->op = Max_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint32;
+			n->op = Max_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_uint64;
+			n->op = Max_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float16;
+			n->op = Max_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float32;
+			n->op = Max_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float64;
+			n->op = Max_float64;
 			break;
 		default:
 			break;
@@ -459,19 +459,19 @@ void resolver_default_op_Max(struct onnx_node_t * n)
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float16;
+			n->op = Max_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float32;
+			n->op = Max_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float64;
+			n->op = Max_float64;
 			break;
 		default:
 			break;
@@ -485,19 +485,19 @@ void resolver_default_op_Max(struct onnx_node_t * n)
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float16;
+			n->op = Max_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float32;
+			n->op = Max_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float64;
+			n->op = Max_float64;
 			break;
 		default:
 			break;
@@ -511,19 +511,19 @@ void resolver_default_op_Max(struct onnx_node_t * n)
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float16;
+			n->op = Max_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float32;
+			n->op = Max_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Max_init;
 			n->exit = Max_exit;
 			n->reshape = Max_reshape;
-			n->operator = Max_float64;
+			n->op = Max_float64;
 			break;
 		default:
 			break;

--- a/src/default/MaxPool.c
+++ b/src/default/MaxPool.c
@@ -423,31 +423,31 @@ void resolver_default_op_MaxPool(struct onnx_node_t * n)
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_int8;
+			n->op = MaxPool_int8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_uint8;
+			n->op = MaxPool_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float16;
+			n->op = MaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float32;
+			n->op = MaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float64;
+			n->op = MaxPool_float64;
 			break;
 		default:
 			break;
@@ -461,19 +461,19 @@ void resolver_default_op_MaxPool(struct onnx_node_t * n)
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float16;
+			n->op = MaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float32;
+			n->op = MaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float64;
+			n->op = MaxPool_float64;
 			break;
 		default:
 			break;
@@ -487,19 +487,19 @@ void resolver_default_op_MaxPool(struct onnx_node_t * n)
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float16;
+			n->op = MaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float32;
+			n->op = MaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float64;
+			n->op = MaxPool_float64;
 			break;
 		default:
 			break;
@@ -513,19 +513,19 @@ void resolver_default_op_MaxPool(struct onnx_node_t * n)
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float16;
+			n->op = MaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float32;
+			n->op = MaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float64;
+			n->op = MaxPool_float64;
 			break;
 		default:
 			break;
@@ -539,19 +539,19 @@ void resolver_default_op_MaxPool(struct onnx_node_t * n)
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float16;
+			n->op = MaxPool_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float32;
+			n->op = MaxPool_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = MaxPool_init;
 			n->exit = MaxPool_exit;
 			n->reshape = MaxPool_reshape;
-			n->operator = MaxPool_float64;
+			n->op = MaxPool_float64;
 			break;
 		default:
 			break;

--- a/src/default/Mean.c
+++ b/src/default/Mean.c
@@ -121,25 +121,25 @@ void resolver_default_op_Mean(struct onnx_node_t * n)
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_bfloat16;
+			n->op = Mean_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float16;
+			n->op = Mean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float32;
+			n->op = Mean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float64;
+			n->op = Mean_float64;
 			break;
 		default:
 			break;
@@ -153,19 +153,19 @@ void resolver_default_op_Mean(struct onnx_node_t * n)
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float16;
+			n->op = Mean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float32;
+			n->op = Mean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float64;
+			n->op = Mean_float64;
 			break;
 		default:
 			break;
@@ -179,19 +179,19 @@ void resolver_default_op_Mean(struct onnx_node_t * n)
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float16;
+			n->op = Mean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float32;
+			n->op = Mean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float64;
+			n->op = Mean_float64;
 			break;
 		default:
 			break;
@@ -205,19 +205,19 @@ void resolver_default_op_Mean(struct onnx_node_t * n)
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float16;
+			n->op = Mean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float32;
+			n->op = Mean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mean_init;
 			n->exit = Mean_exit;
 			n->reshape = Mean_reshape;
-			n->operator = Mean_float64;
+			n->op = Mean_float64;
 			break;
 		default:
 			break;

--- a/src/default/Min.c
+++ b/src/default/Min.c
@@ -305,73 +305,73 @@ void resolver_default_op_Min(struct onnx_node_t * n)
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int8;
+			n->op = Min_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int16;
+			n->op = Min_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int32;
+			n->op = Min_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int64;
+			n->op = Min_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint8;
+			n->op = Min_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint16;
+			n->op = Min_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint32;
+			n->op = Min_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint64;
+			n->op = Min_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_bfloat16;
+			n->op = Min_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float16;
+			n->op = Min_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float32;
+			n->op = Min_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float64;
+			n->op = Min_float64;
 			break;
 		default:
 			break;
@@ -385,67 +385,67 @@ void resolver_default_op_Min(struct onnx_node_t * n)
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int8;
+			n->op = Min_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int16;
+			n->op = Min_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int32;
+			n->op = Min_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_int64;
+			n->op = Min_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint8;
+			n->op = Min_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint16;
+			n->op = Min_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint32;
+			n->op = Min_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_uint64;
+			n->op = Min_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float16;
+			n->op = Min_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float32;
+			n->op = Min_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float64;
+			n->op = Min_float64;
 			break;
 		default:
 			break;
@@ -459,19 +459,19 @@ void resolver_default_op_Min(struct onnx_node_t * n)
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float16;
+			n->op = Min_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float32;
+			n->op = Min_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float64;
+			n->op = Min_float64;
 			break;
 		default:
 			break;
@@ -485,19 +485,19 @@ void resolver_default_op_Min(struct onnx_node_t * n)
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float16;
+			n->op = Min_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float32;
+			n->op = Min_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float64;
+			n->op = Min_float64;
 			break;
 		default:
 			break;
@@ -511,19 +511,19 @@ void resolver_default_op_Min(struct onnx_node_t * n)
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float16;
+			n->op = Min_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float32;
+			n->op = Min_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Min_init;
 			n->exit = Min_exit;
 			n->reshape = Min_reshape;
-			n->operator = Min_float64;
+			n->op = Min_float64;
 			break;
 		default:
 			break;

--- a/src/default/Mod.c
+++ b/src/default/Mod.c
@@ -373,73 +373,73 @@ void resolver_default_op_Mod(struct onnx_node_t * n)
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int8;
+			n->op = Mod_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int16;
+			n->op = Mod_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int32;
+			n->op = Mod_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int64;
+			n->op = Mod_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint8;
+			n->op = Mod_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint16;
+			n->op = Mod_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint32;
+			n->op = Mod_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint64;
+			n->op = Mod_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_bfloat16;
+			n->op = Mod_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float16;
+			n->op = Mod_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float32;
+			n->op = Mod_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float64;
+			n->op = Mod_float64;
 			break;
 		default:
 			break;
@@ -453,67 +453,67 @@ void resolver_default_op_Mod(struct onnx_node_t * n)
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int8;
+			n->op = Mod_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int16;
+			n->op = Mod_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int32;
+			n->op = Mod_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_int64;
+			n->op = Mod_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint8;
+			n->op = Mod_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint16;
+			n->op = Mod_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint32;
+			n->op = Mod_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_uint64;
+			n->op = Mod_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float16;
+			n->op = Mod_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float32;
+			n->op = Mod_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mod_init;
 			n->exit = Mod_exit;
 			n->reshape = Mod_reshape;
-			n->operator = Mod_float64;
+			n->op = Mod_float64;
 			break;
 		default:
 			break;

--- a/src/default/Mul.c
+++ b/src/default/Mul.c
@@ -235,73 +235,73 @@ void resolver_default_op_Mul(struct onnx_node_t * n)
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int8;
+			n->op = Mul_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int16;
+			n->op = Mul_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int32;
+			n->op = Mul_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int64;
+			n->op = Mul_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint8;
+			n->op = Mul_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint16;
+			n->op = Mul_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint32;
+			n->op = Mul_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint64;
+			n->op = Mul_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_bfloat16;
+			n->op = Mul_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float16;
+			n->op = Mul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float32;
+			n->op = Mul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float64;
+			n->op = Mul_float64;
 			break;
 		default:
 			break;
@@ -315,49 +315,49 @@ void resolver_default_op_Mul(struct onnx_node_t * n)
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int32;
+			n->op = Mul_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int64;
+			n->op = Mul_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint32;
+			n->op = Mul_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint64;
+			n->op = Mul_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_bfloat16;
+			n->op = Mul_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float16;
+			n->op = Mul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float32;
+			n->op = Mul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float64;
+			n->op = Mul_float64;
 			break;
 		default:
 			break;
@@ -371,43 +371,43 @@ void resolver_default_op_Mul(struct onnx_node_t * n)
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int32;
+			n->op = Mul_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_int64;
+			n->op = Mul_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint32;
+			n->op = Mul_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_uint64;
+			n->op = Mul_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float16;
+			n->op = Mul_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float32;
+			n->op = Mul_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Mul_init;
 			n->exit = Mul_exit;
 			n->reshape = Mul_reshape;
-			n->operator = Mul_float64;
+			n->op = Mul_float64;
 			break;
 		default:
 			break;

--- a/src/default/Multinomial.c
+++ b/src/default/Multinomial.c
@@ -260,19 +260,19 @@ void resolver_default_op_Multinomial(struct onnx_node_t * n)
 			n->init = Multinomial_init;
 			n->exit = Multinomial_exit;
 			n->reshape = Multinomial_reshape;
-			n->operator = Multinomial_float16;
+			n->op = Multinomial_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Multinomial_init;
 			n->exit = Multinomial_exit;
 			n->reshape = Multinomial_reshape;
-			n->operator = Multinomial_float32;
+			n->op = Multinomial_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Multinomial_init;
 			n->exit = Multinomial_exit;
 			n->reshape = Multinomial_reshape;
-			n->operator = Multinomial_float64;
+			n->op = Multinomial_float64;
 			break;
 		default:
 			break;

--- a/src/default/Neg.c
+++ b/src/default/Neg.c
@@ -126,49 +126,49 @@ void resolver_default_op_Neg(struct onnx_node_t * n)
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int8;
+			n->op = Neg_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int16;
+			n->op = Neg_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int32;
+			n->op = Neg_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int64;
+			n->op = Neg_int64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_bfloat16;
+			n->op = Neg_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float16;
+			n->op = Neg_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float32;
+			n->op = Neg_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float64;
+			n->op = Neg_float64;
 			break;
 		default:
 			break;
@@ -182,43 +182,43 @@ void resolver_default_op_Neg(struct onnx_node_t * n)
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int8;
+			n->op = Neg_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int16;
+			n->op = Neg_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int32;
+			n->op = Neg_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_int64;
+			n->op = Neg_int64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float16;
+			n->op = Neg_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float32;
+			n->op = Neg_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float64;
+			n->op = Neg_float64;
 			break;
 		default:
 			break;
@@ -232,19 +232,19 @@ void resolver_default_op_Neg(struct onnx_node_t * n)
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float16;
+			n->op = Neg_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float32;
+			n->op = Neg_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Neg_init;
 			n->exit = Neg_exit;
 			n->reshape = Neg_reshape;
-			n->operator = Neg_float64;
+			n->op = Neg_float64;
 			break;
 		default:
 			break;

--- a/src/default/Not.c
+++ b/src/default/Not.c
@@ -41,7 +41,7 @@ void resolver_default_op_Not(struct onnx_node_t * n)
 			n->init = Not_init;
 			n->exit = Not_exit;
 			n->reshape = Not_reshape;
-			n->operator = Not_bool;
+			n->op = Not_bool;
 			break;
 		default:
 			break;

--- a/src/default/Or.c
+++ b/src/default/Or.c
@@ -48,7 +48,7 @@ void resolver_default_op_Or(struct onnx_node_t * n)
 			n->init = Or_init;
 			n->exit = Or_exit;
 			n->reshape = Or_reshape;
-			n->operator = Or_bool;
+			n->op = Or_bool;
 			break;
 		default:
 			break;

--- a/src/default/PRelu.c
+++ b/src/default/PRelu.c
@@ -179,43 +179,43 @@ void resolver_default_op_PRelu(struct onnx_node_t * n)
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_int32;
+			n->op = PRelu_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_int64;
+			n->op = PRelu_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_uint32;
+			n->op = PRelu_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_uint64;
+			n->op = PRelu_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float16;
+			n->op = PRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float32;
+			n->op = PRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float64;
+			n->op = PRelu_float64;
 			break;
 		default:
 			break;
@@ -229,19 +229,19 @@ void resolver_default_op_PRelu(struct onnx_node_t * n)
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float16;
+			n->op = PRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float32;
+			n->op = PRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float64;
+			n->op = PRelu_float64;
 			break;
 		default:
 			break;
@@ -255,19 +255,19 @@ void resolver_default_op_PRelu(struct onnx_node_t * n)
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float16;
+			n->op = PRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float32;
+			n->op = PRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float64;
+			n->op = PRelu_float64;
 			break;
 		default:
 			break;
@@ -281,19 +281,19 @@ void resolver_default_op_PRelu(struct onnx_node_t * n)
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float16;
+			n->op = PRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float32;
+			n->op = PRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = PRelu_init;
 			n->exit = PRelu_exit;
 			n->reshape = PRelu_reshape;
-			n->operator = PRelu_float64;
+			n->op = PRelu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Pow.c
+++ b/src/default/Pow.c
@@ -197,37 +197,37 @@ void resolver_default_op_Pow(struct onnx_node_t * n)
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_int32;
+			n->op = Pow_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_int64;
+			n->op = Pow_int64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_bfloat16;
+			n->op = Pow_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float16;
+			n->op = Pow_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float32;
+			n->op = Pow_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float64;
+			n->op = Pow_float64;
 			break;
 		default:
 			break;
@@ -241,31 +241,31 @@ void resolver_default_op_Pow(struct onnx_node_t * n)
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_int32;
+			n->op = Pow_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_int64;
+			n->op = Pow_int64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float16;
+			n->op = Pow_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float32;
+			n->op = Pow_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float64;
+			n->op = Pow_float64;
 			break;
 		default:
 			break;
@@ -279,19 +279,19 @@ void resolver_default_op_Pow(struct onnx_node_t * n)
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float16;
+			n->op = Pow_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float32;
+			n->op = Pow_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Pow_init;
 			n->exit = Pow_exit;
 			n->reshape = Pow_reshape;
-			n->operator = Pow_float64;
+			n->op = Pow_float64;
 			break;
 		default:
 			break;

--- a/src/default/RandomNormal.c
+++ b/src/default/RandomNormal.c
@@ -120,6 +120,6 @@ void resolver_default_op_RandomNormal(struct onnx_node_t * n)
 		n->init = RandomNormal_init;
 		n->exit = RandomNormal_exit;
 		n->reshape = RandomNormal_reshape;
-		n->operator = RandomNormal_operator;
+		n->op = RandomNormal_operator;
 	}
 }

--- a/src/default/RandomNormalLike.c
+++ b/src/default/RandomNormalLike.c
@@ -116,6 +116,6 @@ void resolver_default_op_RandomNormalLike(struct onnx_node_t * n)
 		n->init = RandomNormalLike_init;
 		n->exit = RandomNormalLike_exit;
 		n->reshape = RandomNormalLike_reshape;
-		n->operator = RandomNormalLike_operator;
+		n->op = RandomNormalLike_operator;
 	}
 }

--- a/src/default/RandomUniform.c
+++ b/src/default/RandomUniform.c
@@ -105,6 +105,6 @@ void resolver_default_op_RandomUniform(struct onnx_node_t * n)
 		n->init = RandomUniform_init;
 		n->exit = RandomUniform_exit;
 		n->reshape = RandomUniform_reshape;
-		n->operator = RandomUniform_operator;
+		n->op = RandomUniform_operator;
 	}
 }

--- a/src/default/RandomUniformLike.c
+++ b/src/default/RandomUniformLike.c
@@ -101,6 +101,6 @@ void resolver_default_op_RandomUniformLike(struct onnx_node_t * n)
 		n->init = RandomUniformLike_init;
 		n->exit = RandomUniformLike_exit;
 		n->reshape = RandomUniformLike_reshape;
-		n->operator = RandomUniformLike_operator;
+		n->op = RandomUniformLike_operator;
 	}
 }

--- a/src/default/Range.c
+++ b/src/default/Range.c
@@ -159,31 +159,31 @@ void resolver_default_op_Range(struct onnx_node_t * n)
 			n->init = Range_init;
 			n->exit = Range_exit;
 			n->reshape = Range_reshape;
-			n->operator = Range_int16;
+			n->op = Range_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Range_init;
 			n->exit = Range_exit;
 			n->reshape = Range_reshape;
-			n->operator = Range_int32;
+			n->op = Range_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Range_init;
 			n->exit = Range_exit;
 			n->reshape = Range_reshape;
-			n->operator = Range_int64;
+			n->op = Range_int64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Range_init;
 			n->exit = Range_exit;
 			n->reshape = Range_reshape;
-			n->operator = Range_float32;
+			n->op = Range_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Range_init;
 			n->exit = Range_exit;
 			n->reshape = Range_reshape;
-			n->operator = Range_float64;
+			n->op = Range_float64;
 			break;
 		default:
 			break;

--- a/src/default/Reciprocal.c
+++ b/src/default/Reciprocal.c
@@ -82,25 +82,25 @@ void resolver_default_op_Reciprocal(struct onnx_node_t * n)
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_bfloat16;
+			n->op = Reciprocal_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float16;
+			n->op = Reciprocal_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float32;
+			n->op = Reciprocal_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float64;
+			n->op = Reciprocal_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Reciprocal(struct onnx_node_t * n)
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float16;
+			n->op = Reciprocal_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float32;
+			n->op = Reciprocal_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float64;
+			n->op = Reciprocal_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Reciprocal(struct onnx_node_t * n)
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float16;
+			n->op = Reciprocal_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float32;
+			n->op = Reciprocal_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Reciprocal_init;
 			n->exit = Reciprocal_exit;
 			n->reshape = Reciprocal_reshape;
-			n->operator = Reciprocal_float64;
+			n->op = Reciprocal_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceL1.c
+++ b/src/default/ReduceL1.c
@@ -635,61 +635,61 @@ void resolver_default_op_ReduceL1(struct onnx_node_t * n)
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int8;
+			n->op = ReduceL1_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int32;
+			n->op = ReduceL1_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int64;
+			n->op = ReduceL1_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint8;
+			n->op = ReduceL1_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint32;
+			n->op = ReduceL1_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint64;
+			n->op = ReduceL1_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_bfloat16;
+			n->op = ReduceL1_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float16;
+			n->op = ReduceL1_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float32;
+			n->op = ReduceL1_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float64;
+			n->op = ReduceL1_float64;
 			break;
 		default:
 			break;
@@ -703,55 +703,55 @@ void resolver_default_op_ReduceL1(struct onnx_node_t * n)
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int8;
+			n->op = ReduceL1_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int32;
+			n->op = ReduceL1_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int64;
+			n->op = ReduceL1_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint8;
+			n->op = ReduceL1_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint32;
+			n->op = ReduceL1_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint64;
+			n->op = ReduceL1_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float16;
+			n->op = ReduceL1_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float32;
+			n->op = ReduceL1_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float64;
+			n->op = ReduceL1_float64;
 			break;
 		default:
 			break;
@@ -765,55 +765,55 @@ void resolver_default_op_ReduceL1(struct onnx_node_t * n)
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int8;
+			n->op = ReduceL1_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int32;
+			n->op = ReduceL1_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_int64;
+			n->op = ReduceL1_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint8;
+			n->op = ReduceL1_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint32;
+			n->op = ReduceL1_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_uint64;
+			n->op = ReduceL1_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float16;
+			n->op = ReduceL1_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float32;
+			n->op = ReduceL1_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL1_init;
 			n->exit = ReduceL1_exit;
 			n->reshape = ReduceL1_reshape;
-			n->operator = ReduceL1_float64;
+			n->op = ReduceL1_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceL2.c
+++ b/src/default/ReduceL2.c
@@ -651,61 +651,61 @@ void resolver_default_op_ReduceL2(struct onnx_node_t * n)
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int8;
+			n->op = ReduceL2_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int32;
+			n->op = ReduceL2_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int64;
+			n->op = ReduceL2_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint8;
+			n->op = ReduceL2_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint32;
+			n->op = ReduceL2_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint64;
+			n->op = ReduceL2_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_bfloat16;
+			n->op = ReduceL2_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float16;
+			n->op = ReduceL2_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float32;
+			n->op = ReduceL2_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float64;
+			n->op = ReduceL2_float64;
 			break;
 		default:
 			break;
@@ -719,55 +719,55 @@ void resolver_default_op_ReduceL2(struct onnx_node_t * n)
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int8;
+			n->op = ReduceL2_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int32;
+			n->op = ReduceL2_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int64;
+			n->op = ReduceL2_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint8;
+			n->op = ReduceL2_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint32;
+			n->op = ReduceL2_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint64;
+			n->op = ReduceL2_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float16;
+			n->op = ReduceL2_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float32;
+			n->op = ReduceL2_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float64;
+			n->op = ReduceL2_float64;
 			break;
 		default:
 			break;
@@ -781,55 +781,55 @@ void resolver_default_op_ReduceL2(struct onnx_node_t * n)
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int8;
+			n->op = ReduceL2_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int32;
+			n->op = ReduceL2_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_int64;
+			n->op = ReduceL2_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint8;
+			n->op = ReduceL2_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint32;
+			n->op = ReduceL2_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_uint64;
+			n->op = ReduceL2_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float16;
+			n->op = ReduceL2_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float32;
+			n->op = ReduceL2_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceL2_init;
 			n->exit = ReduceL2_exit;
 			n->reshape = ReduceL2_reshape;
-			n->operator = ReduceL2_float64;
+			n->op = ReduceL2_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceLogSum.c
+++ b/src/default/ReduceLogSum.c
@@ -635,61 +635,61 @@ void resolver_default_op_ReduceLogSum(struct onnx_node_t * n)
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int8;
+			n->op = ReduceLogSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int32;
+			n->op = ReduceLogSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int64;
+			n->op = ReduceLogSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint8;
+			n->op = ReduceLogSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint32;
+			n->op = ReduceLogSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint64;
+			n->op = ReduceLogSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_bfloat16;
+			n->op = ReduceLogSum_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float16;
+			n->op = ReduceLogSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float32;
+			n->op = ReduceLogSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float64;
+			n->op = ReduceLogSum_float64;
 			break;
 		default:
 			break;
@@ -703,55 +703,55 @@ void resolver_default_op_ReduceLogSum(struct onnx_node_t * n)
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int8;
+			n->op = ReduceLogSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int32;
+			n->op = ReduceLogSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int64;
+			n->op = ReduceLogSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint8;
+			n->op = ReduceLogSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint32;
+			n->op = ReduceLogSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint64;
+			n->op = ReduceLogSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float16;
+			n->op = ReduceLogSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float32;
+			n->op = ReduceLogSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float64;
+			n->op = ReduceLogSum_float64;
 			break;
 		default:
 			break;
@@ -765,55 +765,55 @@ void resolver_default_op_ReduceLogSum(struct onnx_node_t * n)
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int8;
+			n->op = ReduceLogSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int32;
+			n->op = ReduceLogSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_int64;
+			n->op = ReduceLogSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint8;
+			n->op = ReduceLogSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint32;
+			n->op = ReduceLogSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_uint64;
+			n->op = ReduceLogSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float16;
+			n->op = ReduceLogSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float32;
+			n->op = ReduceLogSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSum_init;
 			n->exit = ReduceLogSum_exit;
 			n->reshape = ReduceLogSum_reshape;
-			n->operator = ReduceLogSum_float64;
+			n->op = ReduceLogSum_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceLogSumExp.c
+++ b/src/default/ReduceLogSumExp.c
@@ -635,61 +635,61 @@ void resolver_default_op_ReduceLogSumExp(struct onnx_node_t * n)
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int8;
+			n->op = ReduceLogSumExp_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int32;
+			n->op = ReduceLogSumExp_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int64;
+			n->op = ReduceLogSumExp_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint8;
+			n->op = ReduceLogSumExp_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint32;
+			n->op = ReduceLogSumExp_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint64;
+			n->op = ReduceLogSumExp_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_bfloat16;
+			n->op = ReduceLogSumExp_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float16;
+			n->op = ReduceLogSumExp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float32;
+			n->op = ReduceLogSumExp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float64;
+			n->op = ReduceLogSumExp_float64;
 			break;
 		default:
 			break;
@@ -703,55 +703,55 @@ void resolver_default_op_ReduceLogSumExp(struct onnx_node_t * n)
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int8;
+			n->op = ReduceLogSumExp_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int32;
+			n->op = ReduceLogSumExp_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int64;
+			n->op = ReduceLogSumExp_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint8;
+			n->op = ReduceLogSumExp_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint32;
+			n->op = ReduceLogSumExp_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint64;
+			n->op = ReduceLogSumExp_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float16;
+			n->op = ReduceLogSumExp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float32;
+			n->op = ReduceLogSumExp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float64;
+			n->op = ReduceLogSumExp_float64;
 			break;
 		default:
 			break;
@@ -765,55 +765,55 @@ void resolver_default_op_ReduceLogSumExp(struct onnx_node_t * n)
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int8;
+			n->op = ReduceLogSumExp_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int32;
+			n->op = ReduceLogSumExp_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_int64;
+			n->op = ReduceLogSumExp_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint8;
+			n->op = ReduceLogSumExp_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint32;
+			n->op = ReduceLogSumExp_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_uint64;
+			n->op = ReduceLogSumExp_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float16;
+			n->op = ReduceLogSumExp_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float32;
+			n->op = ReduceLogSumExp_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceLogSumExp_init;
 			n->exit = ReduceLogSumExp_exit;
 			n->reshape = ReduceLogSumExp_reshape;
-			n->operator = ReduceLogSumExp_float64;
+			n->op = ReduceLogSumExp_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceMax.c
+++ b/src/default/ReduceMax.c
@@ -655,61 +655,61 @@ void resolver_default_op_ReduceMax(struct onnx_node_t * n)
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int8;
+			n->op = ReduceMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int32;
+			n->op = ReduceMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int64;
+			n->op = ReduceMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint8;
+			n->op = ReduceMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint32;
+			n->op = ReduceMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint64;
+			n->op = ReduceMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_bfloat16;
+			n->op = ReduceMax_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float16;
+			n->op = ReduceMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float32;
+			n->op = ReduceMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float64;
+			n->op = ReduceMax_float64;
 			break;
 		default:
 			break;
@@ -723,55 +723,55 @@ void resolver_default_op_ReduceMax(struct onnx_node_t * n)
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int8;
+			n->op = ReduceMax_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int32;
+			n->op = ReduceMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int64;
+			n->op = ReduceMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint8;
+			n->op = ReduceMax_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint32;
+			n->op = ReduceMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint64;
+			n->op = ReduceMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float16;
+			n->op = ReduceMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float32;
+			n->op = ReduceMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float64;
+			n->op = ReduceMax_float64;
 			break;
 		default:
 			break;
@@ -785,43 +785,43 @@ void resolver_default_op_ReduceMax(struct onnx_node_t * n)
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int32;
+			n->op = ReduceMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int64;
+			n->op = ReduceMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint32;
+			n->op = ReduceMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint64;
+			n->op = ReduceMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float16;
+			n->op = ReduceMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float32;
+			n->op = ReduceMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float64;
+			n->op = ReduceMax_float64;
 			break;
 		default:
 			break;
@@ -835,43 +835,43 @@ void resolver_default_op_ReduceMax(struct onnx_node_t * n)
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int32;
+			n->op = ReduceMax_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_int64;
+			n->op = ReduceMax_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint32;
+			n->op = ReduceMax_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_uint64;
+			n->op = ReduceMax_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float16;
+			n->op = ReduceMax_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float32;
+			n->op = ReduceMax_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMax_init;
 			n->exit = ReduceMax_exit;
 			n->reshape = ReduceMax_reshape;
-			n->operator = ReduceMax_float64;
+			n->op = ReduceMax_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceMean.c
+++ b/src/default/ReduceMean.c
@@ -655,61 +655,61 @@ void resolver_default_op_ReduceMean(struct onnx_node_t * n)
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int8;
+			n->op = ReduceMean_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int32;
+			n->op = ReduceMean_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int64;
+			n->op = ReduceMean_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint8;
+			n->op = ReduceMean_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint32;
+			n->op = ReduceMean_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint64;
+			n->op = ReduceMean_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_bfloat16;
+			n->op = ReduceMean_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float16;
+			n->op = ReduceMean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float32;
+			n->op = ReduceMean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float64;
+			n->op = ReduceMean_float64;
 			break;
 		default:
 			break;
@@ -723,55 +723,55 @@ void resolver_default_op_ReduceMean(struct onnx_node_t * n)
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int8;
+			n->op = ReduceMean_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int32;
+			n->op = ReduceMean_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int64;
+			n->op = ReduceMean_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint8;
+			n->op = ReduceMean_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint32;
+			n->op = ReduceMean_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint64;
+			n->op = ReduceMean_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float16;
+			n->op = ReduceMean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float32;
+			n->op = ReduceMean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float64;
+			n->op = ReduceMean_float64;
 			break;
 		default:
 			break;
@@ -785,55 +785,55 @@ void resolver_default_op_ReduceMean(struct onnx_node_t * n)
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int8;
+			n->op = ReduceMean_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int32;
+			n->op = ReduceMean_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_int64;
+			n->op = ReduceMean_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint8;
+			n->op = ReduceMean_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint32;
+			n->op = ReduceMean_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_uint64;
+			n->op = ReduceMean_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float16;
+			n->op = ReduceMean_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float32;
+			n->op = ReduceMean_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMean_init;
 			n->exit = ReduceMean_exit;
 			n->reshape = ReduceMean_reshape;
-			n->operator = ReduceMean_float64;
+			n->op = ReduceMean_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceMin.c
+++ b/src/default/ReduceMin.c
@@ -655,61 +655,61 @@ void resolver_default_op_ReduceMin(struct onnx_node_t * n)
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int8;
+			n->op = ReduceMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int32;
+			n->op = ReduceMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int64;
+			n->op = ReduceMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint8;
+			n->op = ReduceMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint32;
+			n->op = ReduceMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint64;
+			n->op = ReduceMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_bfloat16;
+			n->op = ReduceMin_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float16;
+			n->op = ReduceMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float32;
+			n->op = ReduceMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float64;
+			n->op = ReduceMin_float64;
 			break;
 		default:
 			break;
@@ -723,55 +723,55 @@ void resolver_default_op_ReduceMin(struct onnx_node_t * n)
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int8;
+			n->op = ReduceMin_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int32;
+			n->op = ReduceMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int64;
+			n->op = ReduceMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint8;
+			n->op = ReduceMin_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint32;
+			n->op = ReduceMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint64;
+			n->op = ReduceMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float16;
+			n->op = ReduceMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float32;
+			n->op = ReduceMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float64;
+			n->op = ReduceMin_float64;
 			break;
 		default:
 			break;
@@ -785,43 +785,43 @@ void resolver_default_op_ReduceMin(struct onnx_node_t * n)
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int32;
+			n->op = ReduceMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int64;
+			n->op = ReduceMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint32;
+			n->op = ReduceMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint64;
+			n->op = ReduceMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float16;
+			n->op = ReduceMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float32;
+			n->op = ReduceMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float64;
+			n->op = ReduceMin_float64;
 			break;
 		default:
 			break;
@@ -835,43 +835,43 @@ void resolver_default_op_ReduceMin(struct onnx_node_t * n)
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int32;
+			n->op = ReduceMin_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_int64;
+			n->op = ReduceMin_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint32;
+			n->op = ReduceMin_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_uint64;
+			n->op = ReduceMin_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float16;
+			n->op = ReduceMin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float32;
+			n->op = ReduceMin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceMin_init;
 			n->exit = ReduceMin_exit;
 			n->reshape = ReduceMin_reshape;
-			n->operator = ReduceMin_float64;
+			n->op = ReduceMin_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceProd.c
+++ b/src/default/ReduceProd.c
@@ -635,61 +635,61 @@ void resolver_default_op_ReduceProd(struct onnx_node_t * n)
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int8;
+			n->op = ReduceProd_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int32;
+			n->op = ReduceProd_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int64;
+			n->op = ReduceProd_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint8;
+			n->op = ReduceProd_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint32;
+			n->op = ReduceProd_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint64;
+			n->op = ReduceProd_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_bfloat16;
+			n->op = ReduceProd_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float16;
+			n->op = ReduceProd_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float32;
+			n->op = ReduceProd_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float64;
+			n->op = ReduceProd_float64;
 			break;
 		default:
 			break;
@@ -703,55 +703,55 @@ void resolver_default_op_ReduceProd(struct onnx_node_t * n)
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int8;
+			n->op = ReduceProd_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int32;
+			n->op = ReduceProd_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int64;
+			n->op = ReduceProd_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint8;
+			n->op = ReduceProd_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint32;
+			n->op = ReduceProd_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint64;
+			n->op = ReduceProd_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float16;
+			n->op = ReduceProd_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float32;
+			n->op = ReduceProd_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float64;
+			n->op = ReduceProd_float64;
 			break;
 		default:
 			break;
@@ -765,55 +765,55 @@ void resolver_default_op_ReduceProd(struct onnx_node_t * n)
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int8;
+			n->op = ReduceProd_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int32;
+			n->op = ReduceProd_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_int64;
+			n->op = ReduceProd_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint8;
+			n->op = ReduceProd_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint32;
+			n->op = ReduceProd_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_uint64;
+			n->op = ReduceProd_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float16;
+			n->op = ReduceProd_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float32;
+			n->op = ReduceProd_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceProd_init;
 			n->exit = ReduceProd_exit;
 			n->reshape = ReduceProd_reshape;
-			n->operator = ReduceProd_float64;
+			n->op = ReduceProd_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceSum.c
+++ b/src/default/ReduceSum.c
@@ -615,61 +615,61 @@ void resolver_default_op_ReduceSum(struct onnx_node_t * n)
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int8;
+			n->op = ReduceSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int32;
+			n->op = ReduceSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int64;
+			n->op = ReduceSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint8;
+			n->op = ReduceSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint32;
+			n->op = ReduceSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint64;
+			n->op = ReduceSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_bfloat16;
+			n->op = ReduceSum_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float16;
+			n->op = ReduceSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float32;
+			n->op = ReduceSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float64;
+			n->op = ReduceSum_float64;
 			break;
 		default:
 			break;
@@ -683,55 +683,55 @@ void resolver_default_op_ReduceSum(struct onnx_node_t * n)
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int8;
+			n->op = ReduceSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int32;
+			n->op = ReduceSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int64;
+			n->op = ReduceSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint8;
+			n->op = ReduceSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint32;
+			n->op = ReduceSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint64;
+			n->op = ReduceSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float16;
+			n->op = ReduceSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float32;
+			n->op = ReduceSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float64;
+			n->op = ReduceSum_float64;
 			break;
 		default:
 			break;
@@ -745,55 +745,55 @@ void resolver_default_op_ReduceSum(struct onnx_node_t * n)
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int8;
+			n->op = ReduceSum_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int32;
+			n->op = ReduceSum_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_int64;
+			n->op = ReduceSum_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint8;
+			n->op = ReduceSum_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint32;
+			n->op = ReduceSum_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_uint64;
+			n->op = ReduceSum_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float16;
+			n->op = ReduceSum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float32;
+			n->op = ReduceSum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSum_init;
 			n->exit = ReduceSum_exit;
 			n->reshape = ReduceSum_reshape;
-			n->operator = ReduceSum_float64;
+			n->op = ReduceSum_float64;
 			break;
 		default:
 			break;

--- a/src/default/ReduceSumSquare.c
+++ b/src/default/ReduceSumSquare.c
@@ -651,61 +651,61 @@ void resolver_default_op_ReduceSumSquare(struct onnx_node_t * n)
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int8;
+			n->op = ReduceSumSquare_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int32;
+			n->op = ReduceSumSquare_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int64;
+			n->op = ReduceSumSquare_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint8;
+			n->op = ReduceSumSquare_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint32;
+			n->op = ReduceSumSquare_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint64;
+			n->op = ReduceSumSquare_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_bfloat16;
+			n->op = ReduceSumSquare_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float16;
+			n->op = ReduceSumSquare_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float32;
+			n->op = ReduceSumSquare_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float64;
+			n->op = ReduceSumSquare_float64;
 			break;
 		default:
 			break;
@@ -719,55 +719,55 @@ void resolver_default_op_ReduceSumSquare(struct onnx_node_t * n)
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int8;
+			n->op = ReduceSumSquare_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int32;
+			n->op = ReduceSumSquare_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int64;
+			n->op = ReduceSumSquare_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint8;
+			n->op = ReduceSumSquare_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint32;
+			n->op = ReduceSumSquare_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint64;
+			n->op = ReduceSumSquare_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float16;
+			n->op = ReduceSumSquare_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float32;
+			n->op = ReduceSumSquare_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float64;
+			n->op = ReduceSumSquare_float64;
 			break;
 		default:
 			break;
@@ -781,55 +781,55 @@ void resolver_default_op_ReduceSumSquare(struct onnx_node_t * n)
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int8;
+			n->op = ReduceSumSquare_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int32;
+			n->op = ReduceSumSquare_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_int64;
+			n->op = ReduceSumSquare_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint8;
+			n->op = ReduceSumSquare_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint32;
+			n->op = ReduceSumSquare_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_uint64;
+			n->op = ReduceSumSquare_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float16;
+			n->op = ReduceSumSquare_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float32;
+			n->op = ReduceSumSquare_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ReduceSumSquare_init;
 			n->exit = ReduceSumSquare_exit;
 			n->reshape = ReduceSumSquare_reshape;
-			n->operator = ReduceSumSquare_float64;
+			n->op = ReduceSumSquare_float64;
 			break;
 		default:
 			break;

--- a/src/default/Relu.c
+++ b/src/default/Relu.c
@@ -130,49 +130,49 @@ void resolver_default_op_Relu(struct onnx_node_t * n)
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_int8;
+			n->op = Relu_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_int16;
+			n->op = Relu_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_int32;
+			n->op = Relu_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_int64;
+			n->op = Relu_int64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_bfloat16;
+			n->op = Relu_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float16;
+			n->op = Relu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float32;
+			n->op = Relu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float64;
+			n->op = Relu_float64;
 			break;
 		default:
 			break;
@@ -186,25 +186,25 @@ void resolver_default_op_Relu(struct onnx_node_t * n)
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_bfloat16;
+			n->op = Relu_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float16;
+			n->op = Relu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float32;
+			n->op = Relu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float64;
+			n->op = Relu_float64;
 			break;
 		default:
 			break;
@@ -218,19 +218,19 @@ void resolver_default_op_Relu(struct onnx_node_t * n)
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float16;
+			n->op = Relu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float32;
+			n->op = Relu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float64;
+			n->op = Relu_float64;
 			break;
 		default:
 			break;
@@ -244,19 +244,19 @@ void resolver_default_op_Relu(struct onnx_node_t * n)
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float16;
+			n->op = Relu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float32;
+			n->op = Relu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Relu_init;
 			n->exit = Relu_exit;
 			n->reshape = Relu_reshape;
-			n->operator = Relu_float64;
+			n->op = Relu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Reshape.c
+++ b/src/default/Reshape.c
@@ -104,7 +104,7 @@ void resolver_default_op_Reshape(struct onnx_node_t * n)
 			n->init = Reshape_init;
 			n->exit = Reshape_exit;
 			n->reshape = Reshape_reshape;
-			n->operator = Reshape_operator;
+			n->op = Reshape_operator;
 			break;
 		default:
 			break;
@@ -133,7 +133,7 @@ void resolver_default_op_Reshape(struct onnx_node_t * n)
 			n->init = Reshape_init;
 			n->exit = Reshape_exit;
 			n->reshape = Reshape_reshape;
-			n->operator = Reshape_operator;
+			n->op = Reshape_operator;
 			break;
 		default:
 			break;
@@ -161,7 +161,7 @@ void resolver_default_op_Reshape(struct onnx_node_t * n)
 			n->init = Reshape_init;
 			n->exit = Reshape_exit;
 			n->reshape = Reshape_reshape;
-			n->operator = Reshape_operator;
+			n->op = Reshape_operator;
 			break;
 		default:
 			break;

--- a/src/default/Round.c
+++ b/src/default/Round.c
@@ -92,19 +92,19 @@ void resolver_default_op_Round(struct onnx_node_t * n)
 			n->init = Round_init;
 			n->exit = Round_exit;
 			n->reshape = Round_reshape;
-			n->operator = Round_float16;
+			n->op = Round_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Round_init;
 			n->exit = Round_exit;
 			n->reshape = Round_reshape;
-			n->operator = Round_float32;
+			n->op = Round_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Round_init;
 			n->exit = Round_exit;
 			n->reshape = Round_reshape;
-			n->operator = Round_float64;
+			n->op = Round_float64;
 			break;
 		default:
 			break;

--- a/src/default/Selu.c
+++ b/src/default/Selu.c
@@ -103,19 +103,19 @@ void resolver_default_op_Selu(struct onnx_node_t * n)
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float16;
+			n->op = Selu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float32;
+			n->op = Selu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float64;
+			n->op = Selu_float64;
 			break;
 		default:
 			break;
@@ -129,19 +129,19 @@ void resolver_default_op_Selu(struct onnx_node_t * n)
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float16;
+			n->op = Selu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float32;
+			n->op = Selu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Selu_init;
 			n->exit = Selu_exit;
 			n->reshape = Selu_reshape;
-			n->operator = Selu_float64;
+			n->op = Selu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Shape.c
+++ b/src/default/Shape.c
@@ -56,7 +56,7 @@ void resolver_default_op_Shape(struct onnx_node_t * n)
 			n->init = Shape_init;
 			n->exit = Shape_exit;
 			n->reshape = Shape_reshape;
-			n->operator = Shape_operator;
+			n->op = Shape_operator;
 			break;
 		default:
 			break;
@@ -84,7 +84,7 @@ void resolver_default_op_Shape(struct onnx_node_t * n)
 			n->init = Shape_init;
 			n->exit = Shape_exit;
 			n->reshape = Shape_reshape;
-			n->operator = Shape_operator;
+			n->op = Shape_operator;
 			break;
 		default:
 			break;

--- a/src/default/Shrink.c
+++ b/src/default/Shrink.c
@@ -261,67 +261,67 @@ void resolver_default_op_Shrink(struct onnx_node_t * n)
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_int8;
+			n->op = Shrink_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_int16;
+			n->op = Shrink_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_int32;
+			n->op = Shrink_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_int64;
+			n->op = Shrink_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_uint8;
+			n->op = Shrink_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_uint16;
+			n->op = Shrink_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_uint32;
+			n->op = Shrink_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_uint64;
+			n->op = Shrink_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_float16;
+			n->op = Shrink_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_float32;
+			n->op = Shrink_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Shrink_init;
 			n->exit = Shrink_exit;
 			n->reshape = Shrink_reshape;
-			n->operator = Shrink_float64;
+			n->op = Shrink_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sigmoid.c
+++ b/src/default/Sigmoid.c
@@ -98,25 +98,25 @@ void resolver_default_op_Sigmoid(struct onnx_node_t * n)
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_bfloat16;
+			n->op = Sigmoid_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float16;
+			n->op = Sigmoid_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float32;
+			n->op = Sigmoid_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float64;
+			n->op = Sigmoid_float64;
 			break;
 		default:
 			break;
@@ -130,19 +130,19 @@ void resolver_default_op_Sigmoid(struct onnx_node_t * n)
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float16;
+			n->op = Sigmoid_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float32;
+			n->op = Sigmoid_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float64;
+			n->op = Sigmoid_float64;
 			break;
 		default:
 			break;
@@ -156,19 +156,19 @@ void resolver_default_op_Sigmoid(struct onnx_node_t * n)
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float16;
+			n->op = Sigmoid_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float32;
+			n->op = Sigmoid_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sigmoid_init;
 			n->exit = Sigmoid_exit;
 			n->reshape = Sigmoid_reshape;
-			n->operator = Sigmoid_float64;
+			n->op = Sigmoid_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sign.c
+++ b/src/default/Sign.c
@@ -250,73 +250,73 @@ void resolver_default_op_Sign(struct onnx_node_t * n)
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int8;
+			n->op = Sign_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int16;
+			n->op = Sign_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int32;
+			n->op = Sign_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int64;
+			n->op = Sign_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint8;
+			n->op = Sign_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint16;
+			n->op = Sign_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint32;
+			n->op = Sign_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint64;
+			n->op = Sign_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_bfloat16;
+			n->op = Sign_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float16;
+			n->op = Sign_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float32;
+			n->op = Sign_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float64;
+			n->op = Sign_float64;
 			break;
 		default:
 			break;
@@ -330,67 +330,67 @@ void resolver_default_op_Sign(struct onnx_node_t * n)
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int8;
+			n->op = Sign_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int16;
+			n->op = Sign_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int32;
+			n->op = Sign_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_int64;
+			n->op = Sign_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint8;
+			n->op = Sign_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint16;
+			n->op = Sign_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint32;
+			n->op = Sign_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_uint64;
+			n->op = Sign_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float16;
+			n->op = Sign_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float32;
+			n->op = Sign_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sign_init;
 			n->exit = Sign_exit;
 			n->reshape = Sign_reshape;
-			n->operator = Sign_float64;
+			n->op = Sign_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sin.c
+++ b/src/default/Sin.c
@@ -67,19 +67,19 @@ void resolver_default_op_Sin(struct onnx_node_t * n)
 			n->init = Sin_init;
 			n->exit = Sin_exit;
 			n->reshape = Sin_reshape;
-			n->operator = Sin_float16;
+			n->op = Sin_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sin_init;
 			n->exit = Sin_exit;
 			n->reshape = Sin_reshape;
-			n->operator = Sin_float32;
+			n->op = Sin_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sin_init;
 			n->exit = Sin_exit;
 			n->reshape = Sin_reshape;
-			n->operator = Sin_float64;
+			n->op = Sin_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sinh.c
+++ b/src/default/Sinh.c
@@ -67,19 +67,19 @@ void resolver_default_op_Sinh(struct onnx_node_t * n)
 			n->init = Sinh_init;
 			n->exit = Sinh_exit;
 			n->reshape = Sinh_reshape;
-			n->operator = Sinh_float16;
+			n->op = Sinh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sinh_init;
 			n->exit = Sinh_exit;
 			n->reshape = Sinh_reshape;
-			n->operator = Sinh_float32;
+			n->op = Sinh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sinh_init;
 			n->exit = Sinh_exit;
 			n->reshape = Sinh_reshape;
-			n->operator = Sinh_float64;
+			n->op = Sinh_float64;
 			break;
 		default:
 			break;

--- a/src/default/Size.c
+++ b/src/default/Size.c
@@ -53,7 +53,7 @@ void resolver_default_op_Size(struct onnx_node_t * n)
 			n->init = Size_init;
 			n->exit = Size_exit;
 			n->reshape = Size_reshape;
-			n->operator = Size_operator;
+			n->op = Size_operator;
 			break;
 		default:
 			break;
@@ -81,7 +81,7 @@ void resolver_default_op_Size(struct onnx_node_t * n)
 			n->init = Size_init;
 			n->exit = Size_exit;
 			n->reshape = Size_reshape;
-			n->operator = Size_operator;
+			n->op = Size_operator;
 			break;
 		default:
 			break;

--- a/src/default/Softmax.c
+++ b/src/default/Softmax.c
@@ -386,25 +386,25 @@ void resolver_default_op_Softmax(struct onnx_node_t * n)
 			n->init = Softmax_13_init;
 			n->exit = Softmax_13_exit;
 			n->reshape = Softmax_13_reshape;
-			n->operator = Softmax_13_bfloat16;
+			n->op = Softmax_13_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Softmax_13_init;
 			n->exit = Softmax_13_exit;
 			n->reshape = Softmax_13_reshape;
-			n->operator = Softmax_13_float16;
+			n->op = Softmax_13_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Softmax_13_init;
 			n->exit = Softmax_13_exit;
 			n->reshape = Softmax_13_reshape;
-			n->operator = Softmax_13_float32;
+			n->op = Softmax_13_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Softmax_13_init;
 			n->exit = Softmax_13_exit;
 			n->reshape = Softmax_13_reshape;
-			n->operator = Softmax_13_float64;
+			n->op = Softmax_13_float64;
 			break;
 		default:
 			break;
@@ -418,19 +418,19 @@ void resolver_default_op_Softmax(struct onnx_node_t * n)
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float16;
+			n->op = Softmax_1_11_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float32;
+			n->op = Softmax_1_11_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float64;
+			n->op = Softmax_1_11_float64;
 			break;
 		default:
 			break;
@@ -444,19 +444,19 @@ void resolver_default_op_Softmax(struct onnx_node_t * n)
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float16;
+			n->op = Softmax_1_11_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float32;
+			n->op = Softmax_1_11_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Softmax_1_11_init;
 			n->exit = Softmax_1_11_exit;
 			n->reshape = Softmax_1_11_reshape;
-			n->operator = Softmax_1_11_float64;
+			n->op = Softmax_1_11_float64;
 			break;
 		default:
 			break;

--- a/src/default/Softplus.c
+++ b/src/default/Softplus.c
@@ -67,19 +67,19 @@ void resolver_default_op_Softplus(struct onnx_node_t * n)
 			n->init = Softplus_init;
 			n->exit = Softplus_exit;
 			n->reshape = Softplus_reshape;
-			n->operator = Softplus_float16;
+			n->op = Softplus_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Softplus_init;
 			n->exit = Softplus_exit;
 			n->reshape = Softplus_reshape;
-			n->operator = Softplus_float32;
+			n->op = Softplus_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Softplus_init;
 			n->exit = Softplus_exit;
 			n->reshape = Softplus_reshape;
-			n->operator = Softplus_float64;
+			n->op = Softplus_float64;
 			break;
 		default:
 			break;

--- a/src/default/Softsign.c
+++ b/src/default/Softsign.c
@@ -67,19 +67,19 @@ void resolver_default_op_Softsign(struct onnx_node_t * n)
 			n->init = Softsign_init;
 			n->exit = Softsign_exit;
 			n->reshape = Softsign_reshape;
-			n->operator = Softsign_float16;
+			n->op = Softsign_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Softsign_init;
 			n->exit = Softsign_exit;
 			n->reshape = Softsign_reshape;
-			n->operator = Softsign_float32;
+			n->op = Softsign_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Softsign_init;
 			n->exit = Softsign_exit;
 			n->reshape = Softsign_reshape;
-			n->operator = Softsign_float64;
+			n->op = Softsign_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sqrt.c
+++ b/src/default/Sqrt.c
@@ -82,25 +82,25 @@ void resolver_default_op_Sqrt(struct onnx_node_t * n)
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_bfloat16;
+			n->op = Sqrt_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float16;
+			n->op = Sqrt_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float32;
+			n->op = Sqrt_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float64;
+			n->op = Sqrt_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Sqrt(struct onnx_node_t * n)
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float16;
+			n->op = Sqrt_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float32;
+			n->op = Sqrt_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float64;
+			n->op = Sqrt_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Sqrt(struct onnx_node_t * n)
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float16;
+			n->op = Sqrt_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float32;
+			n->op = Sqrt_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sqrt_init;
 			n->exit = Sqrt_exit;
 			n->reshape = Sqrt_reshape;
-			n->operator = Sqrt_float64;
+			n->op = Sqrt_float64;
 			break;
 		default:
 			break;

--- a/src/default/Squeeze.c
+++ b/src/default/Squeeze.c
@@ -107,7 +107,7 @@ void resolver_default_op_Squeeze(struct onnx_node_t * n)
 			n->init = Squeeze_init;
 			n->exit = Squeeze_exit;
 			n->reshape = Squeeze_reshape;
-			n->operator = Squeeze_operator;
+			n->op = Squeeze_operator;
 			break;
 		default:
 			break;

--- a/src/default/Sub.c
+++ b/src/default/Sub.c
@@ -235,73 +235,73 @@ void resolver_default_op_Sub(struct onnx_node_t * n)
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int8;
+			n->op = Sub_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int16;
+			n->op = Sub_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int32;
+			n->op = Sub_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int64;
+			n->op = Sub_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint8;
+			n->op = Sub_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint16;
+			n->op = Sub_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint32;
+			n->op = Sub_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint64;
+			n->op = Sub_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_bfloat16;
+			n->op = Sub_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float16;
+			n->op = Sub_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float32;
+			n->op = Sub_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float64;
+			n->op = Sub_float64;
 			break;
 		default:
 			break;
@@ -315,49 +315,49 @@ void resolver_default_op_Sub(struct onnx_node_t * n)
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int32;
+			n->op = Sub_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int64;
+			n->op = Sub_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint32;
+			n->op = Sub_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint64;
+			n->op = Sub_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_bfloat16;
+			n->op = Sub_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float16;
+			n->op = Sub_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float32;
+			n->op = Sub_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float64;
+			n->op = Sub_float64;
 			break;
 		default:
 			break;
@@ -371,43 +371,43 @@ void resolver_default_op_Sub(struct onnx_node_t * n)
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int32;
+			n->op = Sub_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_int64;
+			n->op = Sub_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint32;
+			n->op = Sub_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_uint64;
+			n->op = Sub_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float16;
+			n->op = Sub_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float32;
+			n->op = Sub_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sub_init;
 			n->exit = Sub_exit;
 			n->reshape = Sub_reshape;
-			n->operator = Sub_float64;
+			n->op = Sub_float64;
 			break;
 		default:
 			break;

--- a/src/default/Sum.c
+++ b/src/default/Sum.c
@@ -121,25 +121,25 @@ void resolver_default_op_Sum(struct onnx_node_t * n)
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_bfloat16;
+			n->op = Sum_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float16;
+			n->op = Sum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float32;
+			n->op = Sum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float64;
+			n->op = Sum_float64;
 			break;
 		default:
 			break;
@@ -153,19 +153,19 @@ void resolver_default_op_Sum(struct onnx_node_t * n)
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float16;
+			n->op = Sum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float32;
+			n->op = Sum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float64;
+			n->op = Sum_float64;
 			break;
 		default:
 			break;
@@ -179,19 +179,19 @@ void resolver_default_op_Sum(struct onnx_node_t * n)
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float16;
+			n->op = Sum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float32;
+			n->op = Sum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float64;
+			n->op = Sum_float64;
 			break;
 		default:
 			break;
@@ -205,19 +205,19 @@ void resolver_default_op_Sum(struct onnx_node_t * n)
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float16;
+			n->op = Sum_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float32;
+			n->op = Sum_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Sum_init;
 			n->exit = Sum_exit;
 			n->reshape = Sum_reshape;
-			n->operator = Sum_float64;
+			n->op = Sum_float64;
 			break;
 		default:
 			break;

--- a/src/default/Tan.c
+++ b/src/default/Tan.c
@@ -67,19 +67,19 @@ void resolver_default_op_Tan(struct onnx_node_t * n)
 			n->init = Tan_init;
 			n->exit = Tan_exit;
 			n->reshape = Tan_reshape;
-			n->operator = Tan_float16;
+			n->op = Tan_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tan_init;
 			n->exit = Tan_exit;
 			n->reshape = Tan_reshape;
-			n->operator = Tan_float32;
+			n->op = Tan_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tan_init;
 			n->exit = Tan_exit;
 			n->reshape = Tan_reshape;
-			n->operator = Tan_float64;
+			n->op = Tan_float64;
 			break;
 		default:
 			break;

--- a/src/default/Tanh.c
+++ b/src/default/Tanh.c
@@ -82,25 +82,25 @@ void resolver_default_op_Tanh(struct onnx_node_t * n)
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_bfloat16;
+			n->op = Tanh_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float16;
+			n->op = Tanh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float32;
+			n->op = Tanh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float64;
+			n->op = Tanh_float64;
 			break;
 		default:
 			break;
@@ -114,19 +114,19 @@ void resolver_default_op_Tanh(struct onnx_node_t * n)
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float16;
+			n->op = Tanh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float32;
+			n->op = Tanh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float64;
+			n->op = Tanh_float64;
 			break;
 		default:
 			break;
@@ -140,19 +140,19 @@ void resolver_default_op_Tanh(struct onnx_node_t * n)
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float16;
+			n->op = Tanh_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float32;
+			n->op = Tanh_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tanh_init;
 			n->exit = Tanh_exit;
 			n->reshape = Tanh_reshape;
-			n->operator = Tanh_float64;
+			n->op = Tanh_float64;
 			break;
 		default:
 			break;

--- a/src/default/ThresholdedRelu.c
+++ b/src/default/ThresholdedRelu.c
@@ -88,19 +88,19 @@ void resolver_default_op_ThresholdedRelu(struct onnx_node_t * n)
 			n->init = ThresholdedRelu_init;
 			n->exit = ThresholdedRelu_exit;
 			n->reshape = ThresholdedRelu_reshape;
-			n->operator = ThresholdedRelu_float16;
+			n->op = ThresholdedRelu_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = ThresholdedRelu_init;
 			n->exit = ThresholdedRelu_exit;
 			n->reshape = ThresholdedRelu_reshape;
-			n->operator = ThresholdedRelu_float32;
+			n->op = ThresholdedRelu_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = ThresholdedRelu_init;
 			n->exit = ThresholdedRelu_exit;
 			n->reshape = ThresholdedRelu_reshape;
-			n->operator = ThresholdedRelu_float64;
+			n->op = ThresholdedRelu_float64;
 			break;
 		default:
 			break;

--- a/src/default/Tile.c
+++ b/src/default/Tile.c
@@ -265,97 +265,97 @@ void resolver_default_op_Tile(struct onnx_node_t * n)
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_bool;
+			n->op = Tile_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int8;
+			n->op = Tile_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int16;
+			n->op = Tile_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int32;
+			n->op = Tile_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int64;
+			n->op = Tile_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint8;
+			n->op = Tile_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint16;
+			n->op = Tile_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint32;
+			n->op = Tile_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint64;
+			n->op = Tile_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_bfloat16;
+			n->op = Tile_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float16;
+			n->op = Tile_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float32;
+			n->op = Tile_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float64;
+			n->op = Tile_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_complex64;
+			n->op = Tile_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_complex128;
+			n->op = Tile_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_string;
+			n->op = Tile_string;
 			break;
 		default:
 			break;
@@ -369,91 +369,91 @@ void resolver_default_op_Tile(struct onnx_node_t * n)
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_bool;
+			n->op = Tile_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int8;
+			n->op = Tile_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int16;
+			n->op = Tile_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int32;
+			n->op = Tile_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_int64;
+			n->op = Tile_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint8;
+			n->op = Tile_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint16;
+			n->op = Tile_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint32;
+			n->op = Tile_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_uint64;
+			n->op = Tile_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float16;
+			n->op = Tile_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float32;
+			n->op = Tile_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_float64;
+			n->op = Tile_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_complex64;
+			n->op = Tile_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_complex128;
+			n->op = Tile_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Tile_init;
 			n->exit = Tile_exit;
 			n->reshape = Tile_reshape;
-			n->operator = Tile_string;
+			n->op = Tile_string;
 			break;
 		default:
 			break;

--- a/src/default/Transpose.c
+++ b/src/default/Transpose.c
@@ -437,97 +437,97 @@ void resolver_default_op_Transpose(struct onnx_node_t * n)
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_bool;
+			n->op = Transpose_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int8;
+			n->op = Transpose_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int16;
+			n->op = Transpose_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int32;
+			n->op = Transpose_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int64;
+			n->op = Transpose_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint8;
+			n->op = Transpose_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint16;
+			n->op = Transpose_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint32;
+			n->op = Transpose_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint64;
+			n->op = Transpose_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_BFLOAT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_bfloat16;
+			n->op = Transpose_bfloat16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float16;
+			n->op = Transpose_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float32;
+			n->op = Transpose_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float64;
+			n->op = Transpose_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_complex64;
+			n->op = Transpose_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_complex128;
+			n->op = Transpose_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_string;
+			n->op = Transpose_string;
 			break;
 		default:
 			break;
@@ -541,91 +541,91 @@ void resolver_default_op_Transpose(struct onnx_node_t * n)
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_bool;
+			n->op = Transpose_bool;
 			break;
 		case ONNX_TENSOR_TYPE_INT8:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int8;
+			n->op = Transpose_int8;
 			break;
 		case ONNX_TENSOR_TYPE_INT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int16;
+			n->op = Transpose_int16;
 			break;
 		case ONNX_TENSOR_TYPE_INT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int32;
+			n->op = Transpose_int32;
 			break;
 		case ONNX_TENSOR_TYPE_INT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_int64;
+			n->op = Transpose_int64;
 			break;
 		case ONNX_TENSOR_TYPE_UINT8:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint8;
+			n->op = Transpose_uint8;
 			break;
 		case ONNX_TENSOR_TYPE_UINT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint16;
+			n->op = Transpose_uint16;
 			break;
 		case ONNX_TENSOR_TYPE_UINT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint32;
+			n->op = Transpose_uint32;
 			break;
 		case ONNX_TENSOR_TYPE_UINT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_uint64;
+			n->op = Transpose_uint64;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT16:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float16;
+			n->op = Transpose_float16;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT32:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float32;
+			n->op = Transpose_float32;
 			break;
 		case ONNX_TENSOR_TYPE_FLOAT64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_float64;
+			n->op = Transpose_float64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX64:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_complex64;
+			n->op = Transpose_complex64;
 			break;
 		case ONNX_TENSOR_TYPE_COMPLEX128:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_complex128;
+			n->op = Transpose_complex128;
 			break;
 		case ONNX_TENSOR_TYPE_STRING:
 			n->init = Transpose_init;
 			n->exit = Transpose_exit;
 			n->reshape = Transpose_reshape;
-			n->operator = Transpose_string;
+			n->op = Transpose_string;
 			break;
 		default:
 			break;

--- a/src/default/Unsqueeze.c
+++ b/src/default/Unsqueeze.c
@@ -87,7 +87,7 @@ void resolver_default_op_Unsqueeze(struct onnx_node_t * n)
 			n->init = Unsqueeze_init;
 			n->exit = Unsqueeze_exit;
 			n->reshape = Unsqueeze_reshape;
-			n->operator = Unsqueeze_operator;
+			n->op = Unsqueeze_operator;
 			break;
 		default:
 			break;

--- a/src/default/Where.c
+++ b/src/default/Where.c
@@ -379,97 +379,97 @@ void resolver_default_op_Where(struct onnx_node_t * n)
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_bool;
+				n->op = Where_bool;
 				break;
 			case ONNX_TENSOR_TYPE_INT8:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_int8;
+				n->op = Where_int8;
 				break;
 			case ONNX_TENSOR_TYPE_INT16:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_int16;
+				n->op = Where_int16;
 				break;
 			case ONNX_TENSOR_TYPE_INT32:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_int32;
+				n->op = Where_int32;
 				break;
 			case ONNX_TENSOR_TYPE_INT64:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_int64;
+				n->op = Where_int64;
 				break;
 			case ONNX_TENSOR_TYPE_UINT8:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_uint8;
+				n->op = Where_uint8;
 				break;
 			case ONNX_TENSOR_TYPE_UINT16:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_uint16;
+				n->op = Where_uint16;
 				break;
 			case ONNX_TENSOR_TYPE_UINT32:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_uint32;
+				n->op = Where_uint32;
 				break;
 			case ONNX_TENSOR_TYPE_UINT64:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_uint64;
+				n->op = Where_uint64;
 				break;
 			case ONNX_TENSOR_TYPE_BFLOAT16:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_bfloat16;
+				n->op = Where_bfloat16;
 				break;
 			case ONNX_TENSOR_TYPE_FLOAT16:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_float16;
+				n->op = Where_float16;
 				break;
 			case ONNX_TENSOR_TYPE_FLOAT32:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_float32;
+				n->op = Where_float32;
 				break;
 			case ONNX_TENSOR_TYPE_FLOAT64:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_float64;
+				n->op = Where_float64;
 				break;
 			case ONNX_TENSOR_TYPE_COMPLEX64:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_complex64;
+				n->op = Where_complex64;
 				break;
 			case ONNX_TENSOR_TYPE_COMPLEX128:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_complex128;
+				n->op = Where_complex128;
 				break;
 			case ONNX_TENSOR_TYPE_STRING:
 				n->init = Where_init;
 				n->exit = Where_exit;
 				n->reshape = Where_reshape;
-				n->operator = Where_string;
+				n->op = Where_string;
 				break;
 			default:
 				break;

--- a/src/default/Xor.c
+++ b/src/default/Xor.c
@@ -48,7 +48,7 @@ void resolver_default_op_Xor(struct onnx_node_t * n)
 			n->init = Xor_init;
 			n->exit = Xor_exit;
 			n->reshape = Xor_reshape;
-			n->operator = Xor_bool;
+			n->op = Xor_bool;
 			break;
 		default:
 			break;

--- a/src/list.h
+++ b/src/list.h
@@ -41,14 +41,14 @@ static inline void init_list_head(struct list_head_t * list)
  * This is only for internal list manipulation where we know
  * the prev/next entries already!
  */
-static inline void __list_add(struct list_head_t * new,
+static inline void __list_add(struct list_head_t * nnew,
 			      struct list_head_t * prev,
 			      struct list_head_t * next)
 {
-	next->prev = new;
-	new->next = next;
-	new->prev = prev;
-	prev->next = new;
+	next->prev = nnew;
+	nnew->next = next;
+	nnew->prev = prev;
+	prev->next = nnew;
 }
 
 /**
@@ -59,9 +59,9 @@ static inline void __list_add(struct list_head_t * new,
  * Insert a new entry after the specified head.
  * This is good for implementing stacks.
  */
-static inline void list_add(struct list_head_t * new, struct list_head_t * head)
+static inline void list_add(struct list_head_t * nnew, struct list_head_t * head)
 {
-	__list_add(new, head, head->next);
+	__list_add(nnew, head, head->next);
 }
 
 /**
@@ -72,9 +72,9 @@ static inline void list_add(struct list_head_t * new, struct list_head_t * head)
  * Insert a new entry before the specified head.
  * This is useful for implementing queues.
  */
-static inline void list_add_tail(struct list_head_t * new, struct list_head_t * head)
+static inline void list_add_tail(struct list_head_t * nnew, struct list_head_t * head)
 {
-	__list_add(new, head->prev, head);
+	__list_add(nnew, head->prev, head);
 }
 
 /*
@@ -116,18 +116,18 @@ static inline void list_del(struct list_head_t *entry)
  * If @old was empty, it will be overwritten.
  */
 static inline void list_replace(struct list_head_t * old,
-				struct list_head_t * new)
+				struct list_head_t * nnew)
 {
-	new->next = old->next;
-	new->next->prev = new;
-	new->prev = old->prev;
-	new->prev->next = new;
+	nnew->next = old->next;
+	nnew->next->prev = nnew;
+	nnew->prev = old->prev;
+	nnew->prev->next = nnew;
 }
 
 static inline void list_replace_init(struct list_head_t * old,
-					struct list_head_t * new)
+					struct list_head_t * nnew)
 {
-	list_replace(old, new);
+	list_replace(old, nnew);
 	init_list_head(old);
 }
 
@@ -784,11 +784,11 @@ static inline int hlist_is_singular_node(struct hlist_node_t * n, struct hlist_h
  * reference of the first entry if it exists.
  */
 static inline void hlist_move_list(struct hlist_head_t * old,
-				   struct hlist_head_t * new)
+				   struct hlist_head_t * nnew)
 {
-	new->first = old->first;
-	if(new->first)
-		new->first->pprev = &new->first;
+	nnew->first = old->first;
+	if(nnew->first)
+		nnew->first->pprev = &nnew->first;
 	old->first = NULL;
 }
 

--- a/src/onnx.c
+++ b/src/onnx.c
@@ -1267,17 +1267,17 @@ struct onnx_graph_t * onnx_graph_alloc(struct onnx_context_t * ctx, Onnx__GraphP
 		for(j = 0; j < ctx->rlen; j++)
 		{
 			resolver_solve_operator(ctx->r[j], n);
-			if(n->operator)
+			if(n->op)
 			{
 				n->r = ctx->r[j];
 				n->rctx = ctx->rctx[j];
 				break;
 			}
 		}
-		if(!n->operator)
+		if(!n->op)
 		{
 			resolver_solve_operator(&resolver_default, n);
-			if(n->operator)
+			if(n->op)
 			{
 				n->r = &resolver_default;
 				n->rctx = NULL;
@@ -1285,8 +1285,8 @@ struct onnx_graph_t * onnx_graph_alloc(struct onnx_context_t * ctx, Onnx__GraphP
 		}
 		if(!n->reshape)
 			n->reshape = reshape_dummy;
-		if(!n->operator)
-			n->operator = operator_dummy;
+		if(!n->op)
+			n->op = operator_dummy;
 		if(n->init)
 		{
 			if(n->init(n) <= 0)
@@ -2200,7 +2200,7 @@ void onnx_run(struct onnx_context_t * ctx)
 		{
 			n = &ctx->g->nodes[i];
 			if(n->reshape(n))
-				n->operator(n);
+				n->op(n);
 		}
 	}
 }

--- a/src/onnx.h
+++ b/src/onnx.h
@@ -71,7 +71,7 @@ struct onnx_node_t {
 	int (*init)(struct onnx_node_t * n);
 	int (*exit)(struct onnx_node_t * n);
 	int (*reshape)(struct onnx_node_t * n);
-	void (*operator)(struct onnx_node_t * n);
+	void (*op)(struct onnx_node_t * n);
 	void * priv;
 };
 


### PR DESCRIPTION
The C code uses identifiers `operator` and `new`, which conflict with C++ keywords.  This PR just rename `operator` to `op` and `new` to `nnew`.

#close #40